### PR TITLE
Fix: Correct timezone handling for account expiration date

### DIFF
--- a/BLAZAMGui/UI/Inputs/DynamicMudInput.razor
+++ b/BLAZAMGui/UI/Inputs/DynamicMudInput.razor
@@ -110,18 +110,46 @@
     {
         get
         {
-            if (Value is DateTime time)
-                if (time != DateTime.MinValue)
-                    return time;
-            return null;
+            if (Value is DateTime timeUtc && timeUtc.Kind == DateTimeKind.Utc)
+            {
+                // Ensure we don't try to convert DateTime.MinValue from UTC to Local,
+                // as it can cause issues depending on the local timezone offset.
+                // DateTime.MinValue should typically represent a non-set or null state here.
+                if (timeUtc == DateTime.MinValue)
+                    return null; 
+                return timeUtc.ToLocalTime(); // Convert UTC from model to Local Time for UI
+            }
+            if (Value is DateTime timeUnspecified) // Handle cases where DateTimeKind might be Unspecified
+            {
+                 if (timeUnspecified == DateTime.MinValue)
+                    return null;
+                // Assuming Unspecified should be treated as UTC if coming from the model,
+                // or consider if it should be an error or logged.
+                // For now, let's assume it should be converted as if it were UTC.
+                // Alternatively, if Unspecified means it's already effectively local, no conversion needed.
+                // Given the backend saves UTC, this path (Value being Unspecified) is less likely
+                // for valid dates loaded from AD but could happen if Value is set from elsewhere.
+                // Safest bet if Value is Unspecified is to treat it as local if it's not MinValue
+                if (timeUnspecified.Kind == DateTimeKind.Unspecified)
+                    return timeUnspecified; // Treat as already local if Unspecified
+                
+                return timeUnspecified.ToLocalTime(); // Defaulting to convert if not explicitly Local
+            }
+            return null; // If Value is not a DateTime or is null
         }
         set
         {
-
-            if (value is T tValue)
-                Value = tValue;
+            // 'value' comes from MudDatePicker, assume it's Local Time or Unspecified (treated as Local)
+            if (value is DateTime timeLocal)
+            {
+                // If MudDatePicker returns Unspecified, assume it's intended as Local
+                var dtToConvert = DateTime.SpecifyKind(timeLocal, DateTimeKind.Local);
+                Value = (T)(object)dtToConvert.ToUniversalTime(); // Convert Local from UI to UTC for model
+            }
             else if (value is null)
-                Value = default;
+            {
+                Value = default(T); // This will set User.ExpireTime to null
+            }
         }
     }
 


### PR DESCRIPTION
The account expiration date UI was experiencing issues due to incorrect DateTimeKind handling between the backend (UTC) and the MudDatePicker component (Local Time). This resulted in the date/time appearing to change after saving, causing the UI to indicate unsaved changes.

This commit addresses the issue by modifying DynamicMudInput.razor:
- When reading the account expiration DateTime from the backend (which is UTC), it's now explicitly converted to Local Time before being passed to MudDatePicker.
- When MudDatePicker provides a new DateTime (assumed to be Local Time), it's explicitly converted to Universal Time (UTC) before being saved back to the model.
- Handling for DateTime.MinValue and null values has been clarified to ensure "never expires" is processed correctly.

This ensures that you see and interact with the date/time in your local timezone, while the backend consistently stores it in UTC as expected by Active Directory's accountExpires attribute (FileTime UTC).