### PR TITLE
Add localization for AppHelpLocalization

### DIFF
--- a/BLAZAMLocalization/AppHelpLocalization.de.resx
+++ b/BLAZAMLocalization/AppHelpLocalization.de.resx
@@ -1,0 +1,267 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Access_Level_Definition" xml:space="preserve">
+    <value>Zugriffsebenen sind eine Vorlage für Berechtigungen, die auf bestimmte Organisationseinheiten für bestimmte Delegierte angewendet werden können.</value>
+  </data>
+  <data name="Access_Level_Object_Missing_Read" xml:space="preserve">
+    <value>Ändern Sie den {0}-Zugriff auf Lesen, um Berechtigungen festzulegen</value>
+  </data>
+  <data name="Authenticator_Setup_One" xml:space="preserve">
+    <value>Scannen Sie den folgenden Code mit Ihrer Authentifizierungs-App</value>
+  </data>
+  <data name="Authenticator_Setup_Two" xml:space="preserve">
+    <value>Geben Sie dann den Passcode ein, um ihn zu aktivieren</value>
+  </data>
+  <data name="Auto_Update_Time_Definition" xml:space="preserve">
+    <value>Die Tageszeit, zu der ein Update automatisch angewendet werden soll.</value>
+  </data>
+  <data name="Confirm_Group_Creation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie diese Gruppe erstellen möchten?</value>
+  </data>
+  <data name="Confirm_OU_Creation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie diese OU erstellen möchten?</value>
+  </data>
+  <data name="Confirm_Save_Changes" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie die Änderungen speichern möchten?</value>
+  </data>
+  <data name="Continue_Processing_Rules" xml:space="preserve">
+    <value>Weitere Regeln verarbeiten</value>
+  </data>
+  <data name="Created" xml:space="preserve">
+    <value>{0} wurde erstellt</value>
+  </data>
+  <data name="Delegate_Definition" xml:space="preserve">
+    <value>Delegierte sind Ihre genehmigten Anwendungsbenutzer. Nur die hier von Ihnen definierten Benutzer oder Benutzer in den folgenden Active Directory-Gruppen (oder verschachtelten Gruppen) mit zugeordneten Berechtigungen oder aktivierter Selbstbearbeitung.</value>
+  </data>
+  <data name="Delegate_Function" xml:space="preserve">
+    <value>Der jedem Delegierten gewährte Zugriff wird durch die zugeordnete Zugriffsebene gesteuert.</value>
+  </data>
+  <data name="Deleted" xml:space="preserve">
+    <value>{0} wurde gelöscht</value>
+  </data>
+  <data name="Delete_API_Token_Confirmation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie dieses API-Token löschen möchten?</value>
+  </data>
+  <data name="Delete_Auth_Token_Confirmation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie die Google Authenticator-MFA deaktivieren möchten?</value>
+  </data>
+  <data name="Deny_Request_Confirmation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie diese Anfrage ablehnen möchten?</value>
+  </data>
+  <data name="Developer_Analytics_Suggestion" xml:space="preserve">
+    <value>Wir bitten Sie, Entwickleranalysen zuzulassen, damit wir verstehen können, wie unsere App verwendet wird, um unsere Bemühungen auf das zu konzentrieren, was unserer Meinung nach für unsere Benutzer am wichtigsten ist.</value>
+  </data>
+  <data name="Developer_Logs_Suggestion" xml:space="preserve">
+    <value>Wir bitten Sie, die Entwicklerprotokollierung zuzulassen, damit wir Blazam schnell und transparent verbessern und unsere Entwicklungsbemühungen unterstützen können.</value>
+  </data>
+  <data name="Duplicate_Delegate" xml:space="preserve">
+    <value>Dieser Delegierte existiert bereits.</value>
+  </data>
+  <data name="Duplicate_Deleted_Delegate" xml:space="preserve">
+    <value>Dieser Delegierte existiert bereits. Er wurde gelöscht. Stellen Sie ihn aus dem Papierkorb wieder her.</value>
+  </data>
+  <data name="Duplicate_Name_Conflict" xml:space="preserve">
+    <value>Dieser Name existiert bereits. Bitte wählen Sie einen anderen Namen.</value>
+  </data>
+  <data name="GA4_Instructions" xml:space="preserve">
+    <value>Richten Sie ein GA4-Konto ein und geben Sie hier Ihre Tracking-ID ein, um Daten über die Nutzung Ihrer Installation zu sammeln.</value>
+  </data>
+  <data name="Invalid_Cert_Type" xml:space="preserve">
+    <value>Kein gültiger Zertifikatstyp.</value>
+  </data>
+  <data name="Invalid_Token_Entered" xml:space="preserve">
+    <value>Das eingegebene Token ist ungültig.</value>
+  </data>
+  <data name="Lacks_Group_Member_Read_Permission" xml:space="preserve">
+    <value>Die Gruppe hat weitere Mitglieder, auf die Sie keinen Zugriff haben.</value>
+  </data>
+  <data name="Lacks_Group_Member_Remove_Permission" xml:space="preserve">
+    <value>Sie haben keine Berechtigung, dieses Gruppenmitglied zu entfernen.</value>
+  </data>
+  <data name="Locked_Out" xml:space="preserve">
+    <value>{0} wurde gesperrt</value>
+  </data>
+  <data name="Mapping_Use_Access_Level" xml:space="preserve">
+    <value>{0}-Zuordnungen verwenden diese Zugriffsebene und werden gelöscht.</value>
+  </data>
+  <data name="Modify_Name_Redirect" xml:space="preserve">
+    <value>Um den Benutzernamen zu ändern, klicken Sie auf die Schaltfläche Umbenennen in der Symbolleiste/im Zahnradmenü.</value>
+  </data>
+  <data name="Navigate_Away_Confirmation" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie wegnavigieren möchten?</value>
+  </data>
+  <data name="News_Provider_Description" xml:space="preserve">
+    <value>Wichtige Updates und Änderungen werden hier veröffentlicht.</value>
+  </data>
+  <data name="No_More_Widgets" xml:space="preserve">
+    <value>Keine weiteren Widgets zum Hinzufügen.</value>
+  </data>
+  <data name="No_News" xml:space="preserve">
+    <value>Hier gibt es nichts Neues zu sehen.</value>
+  </data>
+  <data name="No_Request_Actions_Available" xml:space="preserve">
+    <value>Für diesen Eintrag sind keine Aktionen zur Anforderung verfügbar.</value>
+  </data>
+  <data name="Overwrite_Auth_Token_Confirmation" xml:space="preserve">
+    <value>Das Generieren eines neuen Authentifizierungstokens macht das vorhandene ungültig!</value>
+  </data>
+  <data name="Rearrange_Dashboard_Help" xml:space="preserve">
+    <value>Dashboard-Widgets neu anordnen, indem Sie Elemente an eine neue Position ziehen.</value>
+  </data>
+  <data name="Rename_Reboot_Message" xml:space="preserve">
+    <value>Ein Administrator hat diese Workstation umbenannt. Sie wird in {0} Sekunden neu gestartet.</value>
+  </data>
+  <data name="Request_To" xml:space="preserve">
+    <value>Anfrage an {0}</value>
+  </data>
+  <data name="Rule_No_Filter_Warning" xml:space="preserve">
+    <value>Diese Regel wird jedes Mal ausgelöst, wenn ein {0} {1} ist.</value>
+  </data>
+  <data name="Stop_On_Rule" xml:space="preserve">
+    <value>Keine weiteren Regeln verarbeiten.</value>
+  </data>
+  <data name="Super_User_Definition" xml:space="preserve">
+    <value>Hat bei Aktivierung vollständigen und uneingeschränkten Zugriff auf die Anwendung.</value>
+  </data>
+  <data name="Unexpected_Error_Occurred" xml:space="preserve">
+    <value>Ein unerwarteter Fehler ist aufgetreten.</value>
+  </data>
+  <data name="Upate_Branch_Definition" xml:space="preserve">
+    <value>Der Release-Branch ist der empfohlene Branch. Die Auswahl von Nightly wird nur für Testinstallationen empfohlen. Dev ist nur für Entwickler.</value>
+  </data>
+  <data name="Updated" xml:space="preserve">
+    <value>{0} wurde aktualisiert</value>
+  </data>
+  <data name="Update_Credential_Is_AD" xml:space="preserve">
+    <value>Die Active Directory-Anmeldeinformationen werden für die Aktualisierung validiert.</value>
+  </data>
+  <data name="Update_Credential_Is_Application" xml:space="preserve">
+    <value>Das Konto, unter dem Blazam ausgeführt wird, kann in das Anwendungsverzeichnis schreiben.
+Dies setzt den Hostcomputer einem unnötigen Risiko aus. Ändern Sie die Anwendungsidentität
+in ein Konto mit geringeren Berechtigungen, um die Sicherheit zu verbessern.</value>
+  </data>
+  <data name="Update_Credential_Is_Custom" xml:space="preserve">
+    <value>Die benutzerdefinierten Aktualisierungsanmeldeinformationen werden für die Aktualisierung validiert.</value>
+  </data>
+  <data name="Update_Credential_Is_Invalid" xml:space="preserve">
+    <value>Es sind keine Anmeldeinformationen mit Schreibberechtigung für das Anwendungsverzeichnis konfiguriert!
+Versuchen Sie, benutzerdefinierte Aktualisierungsanmeldeinformationen zu konfigurieren.</value>
+  </data>
+</root>

--- a/BLAZAMLocalization/AppHelpLocalization.es.resx
+++ b/BLAZAMLocalization/AppHelpLocalization.es.resx
@@ -1,0 +1,267 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Access_Level_Definition" xml:space="preserve">
+    <value>Los niveles de acceso son una plantilla de permisos que se pueden aplicar a unidades organizativas específicas para delegados específicos.</value>
+  </data>
+  <data name="Access_Level_Object_Missing_Read" xml:space="preserve">
+    <value>Cambie el acceso de {0} a Lectura para establecer permisos</value>
+  </data>
+  <data name="Authenticator_Setup_One" xml:space="preserve">
+    <value>Escanee el código a continuación desde su aplicación de autenticación</value>
+  </data>
+  <data name="Authenticator_Setup_Two" xml:space="preserve">
+    <value>Luego ingrese el código de acceso para activar</value>
+  </data>
+  <data name="Auto_Update_Time_Definition" xml:space="preserve">
+    <value>La hora de cada día para aplicar automáticamente una actualización.</value>
+  </data>
+  <data name="Confirm_Group_Creation" xml:space="preserve">
+    <value>¿Está seguro de que desea crear este grupo?</value>
+  </data>
+  <data name="Confirm_OU_Creation" xml:space="preserve">
+    <value>¿Está seguro de que desea crear esta OU?</value>
+  </data>
+  <data name="Confirm_Save_Changes" xml:space="preserve">
+    <value>¿Está seguro de que desea guardar los cambios?</value>
+  </data>
+  <data name="Continue_Processing_Rules" xml:space="preserve">
+    <value>Continuar procesando otras reglas</value>
+  </data>
+  <data name="Created" xml:space="preserve">
+    <value>{0} ha sido creado</value>
+  </data>
+  <data name="Delegate_Definition" xml:space="preserve">
+    <value>Los delegados son los usuarios aprobados de la aplicación. Solo los usuarios que defina aquí, o los usuarios de los siguientes grupos de Active Directory (o grupos anidados) con permisos asignados o autoedición habilitada.</value>
+  </data>
+  <data name="Delegate_Function" xml:space="preserve">
+    <value>El acceso permitido a cada delegado se controla mediante el nivel de acceso asignado.</value>
+  </data>
+  <data name="Deleted" xml:space="preserve">
+    <value>{0} ha sido eliminado</value>
+  </data>
+  <data name="Delete_API_Token_Confirmation" xml:space="preserve">
+    <value>¿Está seguro de que desea eliminar este token de API?</value>
+  </data>
+  <data name="Delete_Auth_Token_Confirmation" xml:space="preserve">
+    <value>¿Está seguro de que desea deshabilitar la MFA de Google Authenticator?</value>
+  </data>
+  <data name="Deny_Request_Confirmation" xml:space="preserve">
+    <value>¿Está seguro de que desea denegar esta solicitud?</value>
+  </data>
+  <data name="Developer_Analytics_Suggestion" xml:space="preserve">
+    <value>Le pedimos que permita el análisis de desarrolladores para que podamos comprender cómo se utiliza nuestra aplicación y centrar nuestros esfuerzos en lo que nuestros usuarios consideran más importante.</value>
+  </data>
+  <data name="Developer_Logs_Suggestion" xml:space="preserve">
+    <value>Le pedimos que permita el registro de desarrolladores para que podamos mejorar Blazam de forma rápida y transparente y para ayudar en nuestros esfuerzos de desarrollo.</value>
+  </data>
+  <data name="Duplicate_Delegate" xml:space="preserve">
+    <value>Ese delegado ya existe.</value>
+  </data>
+  <data name="Duplicate_Deleted_Delegate" xml:space="preserve">
+    <value>Ese delegado ya existe. Ha sido eliminado. Restaurelo desde la papelera.</value>
+  </data>
+  <data name="Duplicate_Name_Conflict" xml:space="preserve">
+    <value>Ese nombre ya existe. Por favor elija un nombre diferente</value>
+  </data>
+  <data name="GA4_Instructions" xml:space="preserve">
+    <value>Configure una cuenta GA4 e ingrese su ID de seguimiento aquí para recopilar datos sobre el uso de su instalación.</value>
+  </data>
+  <data name="Invalid_Cert_Type" xml:space="preserve">
+    <value>No es un tipo de certificado válido.</value>
+  </data>
+  <data name="Invalid_Token_Entered" xml:space="preserve">
+    <value>El token ingresado no es válido</value>
+  </data>
+  <data name="Lacks_Group_Member_Read_Permission" xml:space="preserve">
+    <value>El grupo tiene más miembros a los que no tiene acceso</value>
+  </data>
+  <data name="Lacks_Group_Member_Remove_Permission" xml:space="preserve">
+    <value>No tiene permiso para eliminar a este miembro del grupo</value>
+  </data>
+  <data name="Locked_Out" xml:space="preserve">
+    <value>{0} ha sido bloqueado</value>
+  </data>
+  <data name="Mapping_Use_Access_Level" xml:space="preserve">
+    <value>Las asignaciones de {0} utilizan este nivel de acceso y se eliminarán</value>
+  </data>
+  <data name="Modify_Name_Redirect" xml:space="preserve">
+    <value>Para modificar el nombre del usuario, haga clic en el botón de cambio de nombre en la barra de herramientas/menú de engranajes</value>
+  </data>
+  <data name="Navigate_Away_Confirmation" xml:space="preserve">
+    <value>¿Está seguro de que desea navegar fuera?</value>
+  </data>
+  <data name="News_Provider_Description" xml:space="preserve">
+    <value>Las actualizaciones y cambios importantes se publican aquí.</value>
+  </data>
+  <data name="No_More_Widgets" xml:space="preserve">
+    <value>No hay más widgets para agregar</value>
+  </data>
+  <data name="No_News" xml:space="preserve">
+    <value>No hay nada nuevo que ver aquí</value>
+  </data>
+  <data name="No_Request_Actions_Available" xml:space="preserve">
+    <value>No hay acciones disponibles para solicitar para esta entrada.</value>
+  </data>
+  <data name="Overwrite_Auth_Token_Confirmation" xml:space="preserve">
+    <value>¡Generar un nuevo token de autenticación invalidará el existente!</value>
+  </data>
+  <data name="Rearrange_Dashboard_Help" xml:space="preserve">
+    <value>Reorganice los widgets del tablero arrastrando elementos a una nueva posición</value>
+  </data>
+  <data name="Rename_Reboot_Message" xml:space="preserve">
+    <value>Un administrador ha cambiado el nombre de esta estación de trabajo. Se reiniciará en {0} segundos.</value>
+  </data>
+  <data name="Request_To" xml:space="preserve">
+    <value>Solicitar a {0}</value>
+  </data>
+  <data name="Rule_No_Filter_Warning" xml:space="preserve">
+    <value>Esta regla se activará cada vez que un {0} sea {1}</value>
+  </data>
+  <data name="Stop_On_Rule" xml:space="preserve">
+    <value>No procesar más reglas</value>
+  </data>
+  <data name="Super_User_Definition" xml:space="preserve">
+    <value>Tendrá acceso completo y total a la aplicación si está habilitado</value>
+  </data>
+  <data name="Unexpected_Error_Occurred" xml:space="preserve">
+    <value>Ha ocurrido un error inesperado.</value>
+  </data>
+  <data name="Upate_Branch_Definition" xml:space="preserve">
+    <value>La rama de lanzamiento es la rama recomendada. Elegir Nightly solo se recomienda para instalaciones de prueba. Dev es solo para desarrolladores.</value>
+  </data>
+  <data name="Updated" xml:space="preserve">
+    <value>{0} ha sido actualizado</value>
+  </data>
+  <data name="Update_Credential_Is_AD" xml:space="preserve">
+    <value>Las credenciales de Active Directory se validan para la actualización.</value>
+  </data>
+  <data name="Update_Credential_Is_Application" xml:space="preserve">
+    <value>La cuenta que ejecuta Blazam puede escribir en el directorio de la aplicación.
+Esto expone la máquina host a un riesgo innecesario. Cambie la identidad de la aplicación
+a una cuenta con privilegios inferiores para mejorar la seguridad.</value>
+  </data>
+  <data name="Update_Credential_Is_Custom" xml:space="preserve">
+    <value>Las credenciales de actualización personalizadas se validan para la actualización.</value>
+  </data>
+  <data name="Update_Credential_Is_Invalid" xml:space="preserve">
+    <value>¡No hay credenciales configuradas con permiso de escritura en el directorio de la aplicación!
+Intente configurar credenciales de actualización personalizadas.</value>
+  </data>
+</root>

--- a/BLAZAMLocalization/AppHelpLocalization.fr.resx
+++ b/BLAZAMLocalization/AppHelpLocalization.fr.resx
@@ -1,0 +1,267 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Access_Level_Definition" xml:space="preserve">
+    <value>Les niveaux d'accès sont un modèle d'autorisations qui peut être appliqué à des unités d'organisation spécifiques pour des délégués spécifiques.</value>
+  </data>
+  <data name="Access_Level_Object_Missing_Read" xml:space="preserve">
+    <value>Changer l'accès de {0} à Lecture pour définir les autorisations</value>
+  </data>
+  <data name="Authenticator_Setup_One" xml:space="preserve">
+    <value>Scannez le code ci-dessous depuis votre application d'authentification</value>
+  </data>
+  <data name="Authenticator_Setup_Two" xml:space="preserve">
+    <value>Saisissez ensuite le mot de passe pour activer</value>
+  </data>
+  <data name="Auto_Update_Time_Definition" xml:space="preserve">
+    <value>L'heure de chaque jour pour appliquer automatiquement une mise à jour.</value>
+  </data>
+  <data name="Confirm_Group_Creation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir créer ce groupe ?</value>
+  </data>
+  <data name="Confirm_OU_Creation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir créer cette UO ?</value>
+  </data>
+  <data name="Confirm_Save_Changes" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir enregistrer les modifications ?</value>
+  </data>
+  <data name="Continue_Processing_Rules" xml:space="preserve">
+    <value>Continuer le traitement des autres règles</value>
+  </data>
+  <data name="Created" xml:space="preserve">
+    <value>{0} a été créé</value>
+  </data>
+  <data name="Delegate_Definition" xml:space="preserve">
+    <value>Les délégués sont vos utilisateurs d'application approuvés. Seuls les utilisateurs que vous définissez ici, ou les utilisateurs des groupes Active Directory suivants (ou des groupes imbriqués) avec des autorisations mappées ou l'auto-édition activée.</value>
+  </data>
+  <data name="Delegate_Function" xml:space="preserve">
+    <value>L'accès autorisé à chaque délégué est contrôlé par le niveau d'accès mappé.</value>
+  </data>
+  <data name="Deleted" xml:space="preserve">
+    <value>{0} a été supprimé</value>
+  </data>
+  <data name="Delete_API_Token_Confirmation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir supprimer ce jeton d'API ?</value>
+  </data>
+  <data name="Delete_Auth_Token_Confirmation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir désactiver l'authentification multifacteur Google Authenticator ?</value>
+  </data>
+  <data name="Deny_Request_Confirmation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir refuser cette demande ?</value>
+  </data>
+  <data name="Developer_Analytics_Suggestion" xml:space="preserve">
+    <value>Nous vous demandons d'autoriser l'analyse des développeurs afin que nous puissions comprendre comment notre application est utilisée pour concentrer nos efforts sur ce que nos utilisateurs pensent être le plus important.</value>
+  </data>
+  <data name="Developer_Logs_Suggestion" xml:space="preserve">
+    <value>Nous vous demandons d'autoriser la journalisation des développeurs afin que nous puissions améliorer Blazam rapidement et de manière transparente et faciliter nos efforts de développement.</value>
+  </data>
+  <data name="Duplicate_Delegate" xml:space="preserve">
+    <value>Ce délégué existe déjà.</value>
+  </data>
+  <data name="Duplicate_Deleted_Delegate" xml:space="preserve">
+    <value>Ce délégué existe déjà. Il a été supprimé. Restaurez-le depuis la corbeille.</value>
+  </data>
+  <data name="Duplicate_Name_Conflict" xml:space="preserve">
+    <value>Ce nom existe déjà. Veuillez choisir un autre nom</value>
+  </data>
+  <data name="GA4_Instructions" xml:space="preserve">
+    <value>Configurez un compte GA4 et saisissez votre ID de suivi ici pour collecter des données sur l'utilisation de votre installation.</value>
+  </data>
+  <data name="Invalid_Cert_Type" xml:space="preserve">
+    <value>Type de certificat non valide.</value>
+  </data>
+  <data name="Invalid_Token_Entered" xml:space="preserve">
+    <value>Le jeton saisi n'est pas valide</value>
+  </data>
+  <data name="Lacks_Group_Member_Read_Permission" xml:space="preserve">
+    <value>Le groupe a plus de membres auxquels vous n'avez pas accès</value>
+  </data>
+  <data name="Lacks_Group_Member_Remove_Permission" xml:space="preserve">
+    <value>Vous n'avez pas l'autorisation de supprimer ce membre du groupe</value>
+  </data>
+  <data name="Locked_Out" xml:space="preserve">
+    <value>{0} a été verrouillé</value>
+  </data>
+  <data name="Mapping_Use_Access_Level" xml:space="preserve">
+    <value>Les mappages {0} utilisent ce niveau d'accès et seront supprimés</value>
+  </data>
+  <data name="Modify_Name_Redirect" xml:space="preserve">
+    <value>Pour modifier le nom de l'utilisateur, cliquez sur le bouton Renommer dans la barre d'outils/le menu engrenage</value>
+  </data>
+  <data name="Navigate_Away_Confirmation" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir quitter la page ?</value>
+  </data>
+  <data name="News_Provider_Description" xml:space="preserve">
+    <value>Les mises à jour et modifications importantes sont publiées ici.</value>
+  </data>
+  <data name="No_More_Widgets" xml:space="preserve">
+    <value>Plus de widgets à ajouter</value>
+  </data>
+  <data name="No_News" xml:space="preserve">
+    <value>Il n'y a rien de nouveau à voir ici</value>
+  </data>
+  <data name="No_Request_Actions_Available" xml:space="preserve">
+    <value>Aucune action n'est disponible à demander pour cette entrée.</value>
+  </data>
+  <data name="Overwrite_Auth_Token_Confirmation" xml:space="preserve">
+    <value>La génération d'un nouveau jeton d'authentification invalidera celui existant !</value>
+  </data>
+  <data name="Rearrange_Dashboard_Help" xml:space="preserve">
+    <value>Réorganiser les widgets du tableau de bord en faisant glisser les éléments vers une nouvelle position</value>
+  </data>
+  <data name="Rename_Reboot_Message" xml:space="preserve">
+    <value>Un administrateur a renommé ce poste de travail. Il redémarrera dans {0} secondes.</value>
+  </data>
+  <data name="Request_To" xml:space="preserve">
+    <value>Demande à {0}</value>
+  </data>
+  <data name="Rule_No_Filter_Warning" xml:space="preserve">
+    <value>Cette règle sera déclenchée chaque fois qu'un {0} est {1}</value>
+  </data>
+  <data name="Stop_On_Rule" xml:space="preserve">
+    <value>Ne plus traiter de règles</value>
+  </data>
+  <data name="Super_User_Definition" xml:space="preserve">
+    <value>Aura un accès complet et total à l'application si activé</value>
+  </data>
+  <data name="Unexpected_Error_Occurred" xml:space="preserve">
+    <value>Une erreur inattendue s'est produite.</value>
+  </data>
+  <data name="Upate_Branch_Definition" xml:space="preserve">
+    <value>La branche de publication est la branche recommandée. Choisir Nightly n'est recommandé que pour les installations de test. Dev est réservé aux développeurs.</value>
+  </data>
+  <data name="Updated" xml:space="preserve">
+    <value>{0} a été mis à jour</value>
+  </data>
+  <data name="Update_Credential_Is_AD" xml:space="preserve">
+    <value>Les informations d'identification Active Directory sont validées pour la mise à jour.</value>
+  </data>
+  <data name="Update_Credential_Is_Application" xml:space="preserve">
+    <value>Le compte exécutant Blazam peut écrire dans le répertoire de l'application.
+Cela expose la machine hôte à un risque inutile. Modifiez l'identité de l'application
+en un compte aux privilèges inférieurs pour améliorer la sécurité.</value>
+  </data>
+  <data name="Update_Credential_Is_Custom" xml:space="preserve">
+    <value>Les informations d'identification de mise à jour personnalisées sont validées pour la mise à jour.</value>
+  </data>
+  <data name="Update_Credential_Is_Invalid" xml:space="preserve">
+    <value>Aucune information d'identification n'est configurée avec une autorisation d'écriture sur le répertoire de l'application !
+Essayez de configurer des informations d'identification de mise à jour personnalisées.</value>
+  </data>
+</root>

--- a/BLAZAMLocalization/AppHelpLocalization.hi.resx
+++ b/BLAZAMLocalization/AppHelpLocalization.hi.resx
@@ -1,0 +1,267 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Access_Level_Definition" xml:space="preserve">
+    <value>पहुँच स्तर अनुमतियों का एक खाका है जिसे विशिष्ट प्रतिनिधियों के लिए विशिष्ट OU पर लागू किया जा सकता है।</value>
+  </data>
+  <data name="Access_Level_Object_Missing_Read" xml:space="preserve">
+    <value>अनुमतियाँ सेट करने के लिए {0} पहुँच को पठन में बदलें</value>
+  </data>
+  <data name="Authenticator_Setup_One" xml:space="preserve">
+    <value>अपने प्रमाणक ऐप से नीचे दिए गए कोड को स्कैन करें</value>
+  </data>
+  <data name="Authenticator_Setup_Two" xml:space="preserve">
+    <value>फिर सक्रिय करने के लिए पासकोड दर्ज करें</value>
+  </data>
+  <data name="Auto_Update_Time_Definition" xml:space="preserve">
+    <value>प्रत्येक दिन का वह समय जब कोई अपडेट स्वचालित रूप से लागू किया जाए।</value>
+  </data>
+  <data name="Confirm_Group_Creation" xml:space="preserve">
+    <value>क्या आप वाकई इस समूह को बनाना चाहते हैं?</value>
+  </data>
+  <data name="Confirm_OU_Creation" xml:space="preserve">
+    <value>क्या आप वाकई इस OU को बनाना चाहते हैं?</value>
+  </data>
+  <data name="Confirm_Save_Changes" xml:space="preserve">
+    <value>क्या आप वाकई परिवर्तनों को सहेजना चाहते हैं?</value>
+  </data>
+  <data name="Continue_Processing_Rules" xml:space="preserve">
+    <value>अन्य नियमों को संसाधित करना जारी रखें</value>
+  </data>
+  <data name="Created" xml:space="preserve">
+    <value>{0} बनाया गया है</value>
+  </data>
+  <data name="Delegate_Definition" xml:space="preserve">
+    <value>प्रतिनिधि आपके अनुमोदित एप्लिकेशन उपयोगकर्ता हैं। केवल वे उपयोगकर्ता जिन्हें आप यहाँ परिभाषित करते हैं, या निम्नलिखित सक्रिय निर्देशिका समूहों (या नेस्टेड समूहों) में उपयोगकर्ता जिनके पास अनुमतियाँ मैप की गई हैं या स्व-संपादन सक्षम है।</value>
+  </data>
+  <data name="Delegate_Function" xml:space="preserve">
+    <value>प्रत्येक प्रतिनिधि को दी गई पहुँच मैप किए गए पहुँच स्तर द्वारा नियंत्रित होती है।</value>
+  </data>
+  <data name="Deleted" xml:space="preserve">
+    <value>{0} हटा दिया गया है</value>
+  </data>
+  <data name="Delete_API_Token_Confirmation" xml:space="preserve">
+    <value>क्या आप वाकई इस API टोकन को हटाना चाहते हैं?</value>
+  </data>
+  <data name="Delete_Auth_Token_Confirmation" xml:space="preserve">
+    <value>क्या आप वाकई Google प्रमाणक MFA को अक्षम करना चाहते हैं?</value>
+  </data>
+  <data name="Deny_Request_Confirmation" xml:space="preserve">
+    <value>क्या आप वाकई इस अनुरोध को अस्वीकार करना चाहते हैं?</value>
+  </data>
+  <data name="Developer_Analytics_Suggestion" xml:space="preserve">
+    <value>हम आपसे डेवलपर एनालिटिक्स की अनुमति देने का अनुरोध करते हैं ताकि हम समझ सकें कि हमारे ऐप का उपयोग कैसे किया जाता है ताकि हमारे प्रयासों को उन चीज़ों पर केंद्रित किया जा सके जो हमारे उपयोगकर्ताओं के विचार में सबसे महत्वपूर्ण हैं।</value>
+  </data>
+  <data name="Developer_Logs_Suggestion" xml:space="preserve">
+    <value>हम आपसे डेवलपर लॉगिंग की अनुमति देने का अनुरोध करते हैं ताकि हम Blazam को तेज़ी से और पारदर्शी रूप से सुधार सकें और हमारे विकास प्रयासों में सहायता कर सकें।</value>
+  </data>
+  <data name="Duplicate_Delegate" xml:space="preserve">
+    <value>वह प्रतिनिधि पहले से मौजूद है।</value>
+  </data>
+  <data name="Duplicate_Deleted_Delegate" xml:space="preserve">
+    <value>वह प्रतिनिधि पहले से मौजूद है। इसे हटा दिया गया है। इसे ट्रैश से पुनर्स्थापित करें।</value>
+  </data>
+  <data name="Duplicate_Name_Conflict" xml:space="preserve">
+    <value>वह नाम पहले से मौजूद है। कृपया कोई दूसरा नाम चुनें</value>
+  </data>
+  <data name="GA4_Instructions" xml:space="preserve">
+    <value>एक GA4 खाता सेट करें और अपनी स्थापना के उपयोग पर डेटा एकत्र करने के लिए यहाँ अपनी ट्रैकिंग आईडी दर्ज करें।</value>
+  </data>
+  <data name="Invalid_Cert_Type" xml:space="preserve">
+    <value>मान्य प्रमाणपत्र प्रकार नहीं है।</value>
+  </data>
+  <data name="Invalid_Token_Entered" xml:space="preserve">
+    <value>दर्ज किया गया टोकन मान्य नहीं है</value>
+  </data>
+  <data name="Lacks_Group_Member_Read_Permission" xml:space="preserve">
+    <value>समूह में और सदस्य हैं जिन तक आपकी पहुँच नहीं है</value>
+  </data>
+  <data name="Lacks_Group_Member_Remove_Permission" xml:space="preserve">
+    <value>आपके पास इस समूह सदस्य को हटाने की अनुमति नहीं है</value>
+  </data>
+  <data name="Locked_Out" xml:space="preserve">
+    <value>{0} को लॉक कर दिया गया है</value>
+  </data>
+  <data name="Mapping_Use_Access_Level" xml:space="preserve">
+    <value>{0} मैपिंग इस पहुँच स्तर का उपयोग करते हैं और हटा दिए जाएँगे</value>
+  </data>
+  <data name="Modify_Name_Redirect" xml:space="preserve">
+    <value>उपयोगकर्ता का नाम संशोधित करने के लिए टूलबार/गियर मेनू में नाम बदलें बटन पर क्लिक करें</value>
+  </data>
+  <data name="Navigate_Away_Confirmation" xml:space="preserve">
+    <value>क्या आप वाकई नेविगेट करना चाहते हैं?</value>
+  </data>
+  <data name="News_Provider_Description" xml:space="preserve">
+    <value>महत्वपूर्ण अपडेट और परिवर्तन यहाँ पोस्ट किए जाते हैं।</value>
+  </data>
+  <data name="No_More_Widgets" xml:space="preserve">
+    <value>जोड़ने के लिए और विजेट नहीं हैं</value>
+  </data>
+  <data name="No_News" xml:space="preserve">
+    <value>यहाँ देखने के लिए कुछ भी नया नहीं है</value>
+  </data>
+  <data name="No_Request_Actions_Available" xml:space="preserve">
+    <value>इस प्रविष्टि के लिए अनुरोध करने के लिए कोई कार्रवाई उपलब्ध नहीं है।</value>
+  </data>
+  <data name="Overwrite_Auth_Token_Confirmation" xml:space="preserve">
+    <value>एक नया प्रमाणक टोकन जनरेट करने से मौजूदा टोकन अमान्य हो जाएगा!</value>
+  </data>
+  <data name="Rearrange_Dashboard_Help" xml:space="preserve">
+    <value>आइटम को नई स्थिति में खींचकर डैशबोर्ड विजेट को पुनर्व्यवस्थित करें</value>
+  </data>
+  <data name="Rename_Reboot_Message" xml:space="preserve">
+    <value>एक व्यवस्थापक ने इस कार्य केंद्र का नाम बदल दिया है। यह {0} सेकंड में रीबूट होगा।</value>
+  </data>
+  <data name="Request_To" xml:space="preserve">
+    <value>{0} से अनुरोध करें</value>
+  </data>
+  <data name="Rule_No_Filter_Warning" xml:space="preserve">
+    <value>यह नियम हर बार तब फायर होगा जब कोई {0} {1} होगा</value>
+  </data>
+  <data name="Stop_On_Rule" xml:space="preserve">
+    <value>और नियम संसाधित न करें</value>
+  </data>
+  <data name="Super_User_Definition" xml:space="preserve">
+    <value>सक्षम होने पर एप्लिकेशन तक पूर्ण और कुल पहुँच होगी</value>
+  </data>
+  <data name="Unexpected_Error_Occurred" xml:space="preserve">
+    <value>एक अप्रत्याशित त्रुटि हुई है।</value>
+  </data>
+  <data name="Upate_Branch_Definition" xml:space="preserve">
+    <value>रिलीज़ शाखा अनुशंसित शाखा है। नाइटली चुनना केवल परीक्षण प्रतिष्ठानों के लिए अनुशंसित है। देव केवल डेवलपर्स के लिए है।</value>
+  </data>
+  <data name="Updated" xml:space="preserve">
+    <value>{0} अपडेट किया गया है</value>
+  </data>
+  <data name="Update_Credential_Is_AD" xml:space="preserve">
+    <value>सक्रिय निर्देशिका क्रेडेंशियल अपडेट करने के लिए मान्य हैं।</value>
+  </data>
+  <data name="Update_Credential_Is_Application" xml:space="preserve">
+    <value>Blazam चलाने वाला खाता एप्लिकेशन निर्देशिका में लिख सकता है।
+यह होस्ट मशीन को अनावश्यक जोखिम में डालता है। एप्लिकेशन पहचान बदलें
+सुरक्षा में सुधार के लिए कम विशेषाधिकार प्राप्त खाते में।</value>
+  </data>
+  <data name="Update_Credential_Is_Custom" xml:space="preserve">
+    <value>कस्टम अपडेट क्रेडेंशियल अपडेट करने के लिए मान्य हैं।</value>
+  </data>
+  <data name="Update_Credential_Is_Invalid" xml:space="preserve">
+    <value>एप्लिकेशन निर्देशिका में लिखने की अनुमति के साथ कोई क्रेडेंशियल कॉन्फ़िगर नहीं किया गया है!
+कस्टम अपडेट क्रेडेंशियल कॉन्फ़िगर करने का प्रयास करें।</value>
+  </data>
+</root>

--- a/BLAZAMLocalization/AppHelpLocalization.it.resx
+++ b/BLAZAMLocalization/AppHelpLocalization.it.resx
@@ -1,0 +1,267 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Access_Level_Definition" xml:space="preserve">
+    <value>I livelli di accesso sono un modello di autorizzazioni che possono essere applicate a specifiche unità organizzative per specifici delegati.</value>
+  </data>
+  <data name="Access_Level_Object_Missing_Read" xml:space="preserve">
+    <value>Modificare l'accesso {0} a Lettura per impostare le autorizzazioni</value>
+  </data>
+  <data name="Authenticator_Setup_One" xml:space="preserve">
+    <value>Scansiona il codice sottostante dalla tua app di autenticazione</value>
+  </data>
+  <data name="Authenticator_Setup_Two" xml:space="preserve">
+    <value>Quindi inserisci il passcode per attivare</value>
+  </data>
+  <data name="Auto_Update_Time_Definition" xml:space="preserve">
+    <value>L'ora di ogni giorno per applicare automaticamente un aggiornamento.</value>
+  </data>
+  <data name="Confirm_Group_Creation" xml:space="preserve">
+    <value>Sei sicuro di voler creare questo gruppo?</value>
+  </data>
+  <data name="Confirm_OU_Creation" xml:space="preserve">
+    <value>Sei sicuro di voler creare questa OU?</value>
+  </data>
+  <data name="Confirm_Save_Changes" xml:space="preserve">
+    <value>Sei sicuro di voler salvare le modifiche?</value>
+  </data>
+  <data name="Continue_Processing_Rules" xml:space="preserve">
+    <value>Continua l'elaborazione di altre regole</value>
+  </data>
+  <data name="Created" xml:space="preserve">
+    <value>{0} è stato creato</value>
+  </data>
+  <data name="Delegate_Definition" xml:space="preserve">
+    <value>I delegati sono gli utenti dell'applicazione approvati. Solo gli utenti definiti qui o gli utenti nei seguenti gruppi di Active Directory (o gruppi nidificati) con autorizzazioni mappate o auto-modifica abilitata.</value>
+  </data>
+  <data name="Delegate_Function" xml:space="preserve">
+    <value>L'accesso consentito a ciascun delegato è controllato dal livello di accesso mappato.</value>
+  </data>
+  <data name="Deleted" xml:space="preserve">
+    <value>{0} è stato eliminato</value>
+  </data>
+  <data name="Delete_API_Token_Confirmation" xml:space="preserve">
+    <value>Sei sicuro di voler eliminare questo token API?</value>
+  </data>
+  <data name="Delete_Auth_Token_Confirmation" xml:space="preserve">
+    <value>Sei sicuro di voler disabilitare Google Authenticator MFA?</value>
+  </data>
+  <data name="Deny_Request_Confirmation" xml:space="preserve">
+    <value>Sei sicuro di voler negare questa richiesta?</value>
+  </data>
+  <data name="Developer_Analytics_Suggestion" xml:space="preserve">
+    <value>Ti chiediamo di consentire l'analisi degli sviluppatori in modo da poter capire come viene utilizzata la nostra app per concentrare i nostri sforzi su ciò che i nostri utenti ritengono più importante.</value>
+  </data>
+  <data name="Developer_Logs_Suggestion" xml:space="preserve">
+    <value>Ti chiediamo di consentire la registrazione degli sviluppatori in modo da poter migliorare Blazam in modo rapido e trasparente e per aiutare i nostri sforzi di sviluppo.</value>
+  </data>
+  <data name="Duplicate_Delegate" xml:space="preserve">
+    <value>Quel delegato esiste già.</value>
+  </data>
+  <data name="Duplicate_Deleted_Delegate" xml:space="preserve">
+    <value>Quel delegato esiste già. È stato eliminato. Ripristinalo dal cestino.</value>
+  </data>
+  <data name="Duplicate_Name_Conflict" xml:space="preserve">
+    <value>Quel nome esiste già. Scegli un nome diverso</value>
+  </data>
+  <data name="GA4_Instructions" xml:space="preserve">
+    <value>Configura un account GA4 e inserisci qui il tuo ID di monitoraggio per raccogliere dati sull'utilizzo della tua installazione.</value>
+  </data>
+  <data name="Invalid_Cert_Type" xml:space="preserve">
+    <value>Tipo di certificato non valido.</value>
+  </data>
+  <data name="Invalid_Token_Entered" xml:space="preserve">
+    <value>Il token inserito non è valido</value>
+  </data>
+  <data name="Lacks_Group_Member_Read_Permission" xml:space="preserve">
+    <value>Il gruppo ha più membri a cui non hai accesso</value>
+  </data>
+  <data name="Lacks_Group_Member_Remove_Permission" xml:space="preserve">
+    <value>Non hai il permesso di rimuovere questo membro del gruppo</value>
+  </data>
+  <data name="Locked_Out" xml:space="preserve">
+    <value>{0} è stato bloccato</value>
+  </data>
+  <data name="Mapping_Use_Access_Level" xml:space="preserve">
+    <value>Le mappature {0} utilizzano questo livello di accesso e verranno eliminate</value>
+  </data>
+  <data name="Modify_Name_Redirect" xml:space="preserve">
+    <value>Per modificare il nome dell'utente, fai clic sul pulsante Rinomina nella barra degli strumenti/menu a ingranaggi</value>
+  </data>
+  <data name="Navigate_Away_Confirmation" xml:space="preserve">
+    <value>Sei sicuro di voler navigare via?</value>
+  </data>
+  <data name="News_Provider_Description" xml:space="preserve">
+    <value>Aggiornamenti e modifiche importanti vengono pubblicati qui.</value>
+  </data>
+  <data name="No_More_Widgets" xml:space="preserve">
+    <value>Nessun altro widget da aggiungere</value>
+  </data>
+  <data name="No_News" xml:space="preserve">
+    <value>Non c'è niente di nuovo da vedere qui</value>
+  </data>
+  <data name="No_Request_Actions_Available" xml:space="preserve">
+    <value>Non ci sono azioni disponibili da richiedere per questa voce.</value>
+  </data>
+  <data name="Overwrite_Auth_Token_Confirmation" xml:space="preserve">
+    <value>La generazione di un nuovo token di autenticazione invaliderà quello esistente!</value>
+  </data>
+  <data name="Rearrange_Dashboard_Help" xml:space="preserve">
+    <value>Riorganizza i widget del dashboard trascinando gli elementi in una nuova posizione</value>
+  </data>
+  <data name="Rename_Reboot_Message" xml:space="preserve">
+    <value>Un amministratore ha rinominato questa workstation. Si riavvierà tra {0} secondi.</value>
+  </data>
+  <data name="Request_To" xml:space="preserve">
+    <value>Richiesta a {0}</value>
+  </data>
+  <data name="Rule_No_Filter_Warning" xml:space="preserve">
+    <value>Questa regola verrà attivata ogni volta che un {0} è {1}</value>
+  </data>
+  <data name="Stop_On_Rule" xml:space="preserve">
+    <value>Non elaborare più regole</value>
+  </data>
+  <data name="Super_User_Definition" xml:space="preserve">
+    <value>Avrà accesso completo e totale all'applicazione se abilitato</value>
+  </data>
+  <data name="Unexpected_Error_Occurred" xml:space="preserve">
+    <value>Si è verificato un errore imprevisto.</value>
+  </data>
+  <data name="Upate_Branch_Definition" xml:space="preserve">
+    <value>Il ramo di rilascio è il ramo consigliato. La scelta di Nightly è consigliata solo per le installazioni di prova. Dev è solo per sviluppatori.</value>
+  </data>
+  <data name="Updated" xml:space="preserve">
+    <value>{0} è stato aggiornato</value>
+  </data>
+  <data name="Update_Credential_Is_AD" xml:space="preserve">
+    <value>Le credenziali di Active Directory sono convalidate per l'aggiornamento.</value>
+  </data>
+  <data name="Update_Credential_Is_Application" xml:space="preserve">
+    <value>L'account che esegue Blazam può scrivere nella directory dell'applicazione.
+Ciò espone la macchina host a rischi inutili. Modificare l'identità dell'applicazione
+a un account con privilegi inferiori per migliorare la sicurezza.</value>
+  </data>
+  <data name="Update_Credential_Is_Custom" xml:space="preserve">
+    <value>Le credenziali di aggiornamento personalizzate sono convalidate per l'aggiornamento.</value>
+  </data>
+  <data name="Update_Credential_Is_Invalid" xml:space="preserve">
+    <value>Non ci sono credenziali configurate con il permesso di scrittura nella directory dell'applicazione!
+Prova a configurare credenziali di aggiornamento personalizzate.</value>
+  </data>
+</root>

--- a/BLAZAMLocalization/AppHelpLocalization.ja.resx
+++ b/BLAZAMLocalization/AppHelpLocalization.ja.resx
@@ -1,0 +1,267 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Access_Level_Definition" xml:space="preserve">
+    <value>アクセスレベルは、特定のデリゲートに対して特定のOUに適用できる権限のテンプレートです。</value>
+  </data>
+  <data name="Access_Level_Object_Missing_Read" xml:space="preserve">
+    <value>権限を設定するには、{0}アクセスを読み取りに変更します</value>
+  </data>
+  <data name="Authenticator_Setup_One" xml:space="preserve">
+    <value>認証アプリから以下のコードをスキャンします</value>
+  </data>
+  <data name="Authenticator_Setup_Two" xml:space="preserve">
+    <value>次に、パスコードを入力してアクティブ化します</value>
+  </data>
+  <data name="Auto_Update_Time_Definition" xml:space="preserve">
+    <value>アップデートを自動的に適用する毎日の時刻。</value>
+  </data>
+  <data name="Confirm_Group_Creation" xml:space="preserve">
+    <value>このグループを作成してもよろしいですか？</value>
+  </data>
+  <data name="Confirm_OU_Creation" xml:space="preserve">
+    <value>このOUを作成してもよろしいですか？</value>
+  </data>
+  <data name="Confirm_Save_Changes" xml:space="preserve">
+    <value>変更を保存してもよろしいですか？</value>
+  </data>
+  <data name="Continue_Processing_Rules" xml:space="preserve">
+    <value>他のルールの処理を続行します</value>
+  </data>
+  <data name="Created" xml:space="preserve">
+    <value>{0}が作成されました</value>
+  </data>
+  <data name="Delegate_Definition" xml:space="preserve">
+    <value>デリゲートは、承認されたアプリケーションユーザーです。ここで定義するユーザー、または次のActive Directoryグループ（またはネストされたグループ）のユーザーで、権限がマップされているか、自己編集が有効になっているユーザーのみです。</value>
+  </data>
+  <data name="Delegate_Function" xml:space="preserve">
+    <value>各デリゲートに許可されるアクセスは、マップされたアクセスレベルによって制御されます。</value>
+  </data>
+  <data name="Deleted" xml:space="preserve">
+    <value>{0}は削除されました</value>
+  </data>
+  <data name="Delete_API_Token_Confirmation" xml:space="preserve">
+    <value>このAPIトークンを削除してもよろしいですか？</value>
+  </data>
+  <data name="Delete_Auth_Token_Confirmation" xml:space="preserve">
+    <value>Google Authenticator MFAを無効にしてもよろしいですか？</value>
+  </data>
+  <data name="Deny_Request_Confirmation" xml:space="preserve">
+    <value>このリクエストを拒否してもよろしいですか？</value>
+  </data>
+  <data name="Developer_Analytics_Suggestion" xml:space="preserve">
+    <value>開発者の分析を許可して、アプリの使用状況を理解し、ユーザーが最も重要と考えるものに注力できるようにしてください。</value>
+  </data>
+  <data name="Developer_Logs_Suggestion" xml:space="preserve">
+    <value>Blazamを迅速かつ透過的に改善し、開発努力を支援するために、開発者ログを許可するようお願いします。</value>
+  </data>
+  <data name="Duplicate_Delegate" xml:space="preserve">
+    <value>そのデリゲートは既に存在します。</value>
+  </data>
+  <data name="Duplicate_Deleted_Delegate" xml:space="preserve">
+    <value>そのデリゲートは既に存在します。削除されました。ゴミ箱から復元してください。</value>
+  </data>
+  <data name="Duplicate_Name_Conflict" xml:space="preserve">
+    <value>その名前は既に存在します。別の名前を選択してください</value>
+  </data>
+  <data name="GA4_Instructions" xml:space="preserve">
+    <value>GA4アカウントを設定し、ここにトラッキングIDを入力して、インストールの使用状況に関するデータを収集します。</value>
+  </data>
+  <data name="Invalid_Cert_Type" xml:space="preserve">
+    <value>有効な証明書タイプではありません。</value>
+  </data>
+  <data name="Invalid_Token_Entered" xml:space="preserve">
+    <value>入力されたトークンは無効です</value>
+  </data>
+  <data name="Lacks_Group_Member_Read_Permission" xml:space="preserve">
+    <value>グループには、アクセスできないメンバーが他にもいます</value>
+  </data>
+  <data name="Lacks_Group_Member_Remove_Permission" xml:space="preserve">
+    <value>このグループメンバーを削除する権限がありません</value>
+  </data>
+  <data name="Locked_Out" xml:space="preserve">
+    <value>{0}はロックアウトされました</value>
+  </data>
+  <data name="Mapping_Use_Access_Level" xml:space="preserve">
+    <value>{0}マッピングはこのアクセスレベルを使用し、削除されます</value>
+  </data>
+  <data name="Modify_Name_Redirect" xml:space="preserve">
+    <value>ユーザー名を変更するには、ツールバー/歯車メニューの名前変更ボタンをクリックします</value>
+  </data>
+  <data name="Navigate_Away_Confirmation" xml:space="preserve">
+    <value>移動してもよろしいですか？</value>
+  </data>
+  <data name="News_Provider_Description" xml:space="preserve">
+    <value>重要な更新と変更はここに投稿されます。</value>
+  </data>
+  <data name="No_More_Widgets" xml:space="preserve">
+    <value>追加するウィジェットはもうありません</value>
+  </data>
+  <data name="No_News" xml:space="preserve">
+    <value>ここには新しいものはありません</value>
+  </data>
+  <data name="No_Request_Actions_Available" xml:space="preserve">
+    <value>このエントリに対してリクエストできるアクションはありません。</value>
+  </data>
+  <data name="Overwrite_Auth_Token_Confirmation" xml:space="preserve">
+    <value>新しい認証トークンを生成すると、既存のトークンが無効になります！</value>
+  </data>
+  <data name="Rearrange_Dashboard_Help" xml:space="preserve">
+    <value>アイテムを新しい位置にドラッグしてダッシュボードウィジェットを再配置します</value>
+  </data>
+  <data name="Rename_Reboot_Message" xml:space="preserve">
+    <value>管理者がこのワークステーションの名前を変更しました。{0}秒後に再起動します。</value>
+  </data>
+  <data name="Request_To" xml:space="preserve">
+    <value>{0}にリクエスト</value>
+  </data>
+  <data name="Rule_No_Filter_Warning" xml:space="preserve">
+    <value>このルールは、{0}が{1}になるたびに起動されます</value>
+  </data>
+  <data name="Stop_On_Rule" xml:space="preserve">
+    <value>これ以上ルールを処理しません</value>
+  </data>
+  <data name="Super_User_Definition" xml:space="preserve">
+    <value>有効にすると、アプリケーションへの完全かつ総合的なアクセスが可能になります</value>
+  </data>
+  <data name="Unexpected_Error_Occurred" xml:space="preserve">
+    <value>予期しないエラーが発生しました。</value>
+  </data>
+  <data name="Upate_Branch_Definition" xml:space="preserve">
+    <value>リリースブランチが推奨ブランチです。ナイトリーの選択は、テストインストールにのみ推奨されます。Devは開発者専用です。</value>
+  </data>
+  <data name="Updated" xml:space="preserve">
+    <value>{0}は更新されました</value>
+  </data>
+  <data name="Update_Credential_Is_AD" xml:space="preserve">
+    <value>Active Directoryの資格情報は更新用に検証されています。</value>
+  </data>
+  <data name="Update_Credential_Is_Application" xml:space="preserve">
+    <value>Blazamを実行しているアカウントは、アプリケーションディレクトリに書き込むことができます。
+これにより、ホストマシンが不必要なリスクにさらされます。アプリケーションIDを変更します
+セキュリティを向上させるために、権限の低いアカウントに。</value>
+  </data>
+  <data name="Update_Credential_Is_Custom" xml:space="preserve">
+    <value>カスタム更新資格情報は更新用に検証されています。</value>
+  </data>
+  <data name="Update_Credential_Is_Invalid" xml:space="preserve">
+    <value>アプリケーションディレクトリへの書き込み権限を持つ資格情報が設定されていません！
+カスタム更新資格情報を設定してみてください。</value>
+  </data>
+</root>

--- a/BLAZAMLocalization/AppHelpLocalization.ko.resx
+++ b/BLAZAMLocalization/AppHelpLocalization.ko.resx
@@ -1,0 +1,267 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Access_Level_Definition" xml:space="preserve">
+    <value>액세스 수준은 특정 위임자에 대해 특정 OU에 적용할 수 있는 권한 템플릿입니다.</value>
+  </data>
+  <data name="Access_Level_Object_Missing_Read" xml:space="preserve">
+    <value>권한을 설정하려면 {0} 액세스를 읽기로 변경하십시오.</value>
+  </data>
+  <data name="Authenticator_Setup_One" xml:space="preserve">
+    <value>인증 앱에서 아래 코드를 스캔하십시오.</value>
+  </data>
+  <data name="Authenticator_Setup_Two" xml:space="preserve">
+    <value>그런 다음 암호를 입력하여 활성화하십시오.</value>
+  </data>
+  <data name="Auto_Update_Time_Definition" xml:space="preserve">
+    <value>매일 업데이트를 자동으로 적용할 시간입니다.</value>
+  </data>
+  <data name="Confirm_Group_Creation" xml:space="preserve">
+    <value>이 그룹을 만드시겠습니까?</value>
+  </data>
+  <data name="Confirm_OU_Creation" xml:space="preserve">
+    <value>이 OU를 만드시겠습니까?</value>
+  </data>
+  <data name="Confirm_Save_Changes" xml:space="preserve">
+    <value>변경 사항을 저장하시겠습니까?</value>
+  </data>
+  <data name="Continue_Processing_Rules" xml:space="preserve">
+    <value>다른 규칙 계속 처리</value>
+  </data>
+  <data name="Created" xml:space="preserve">
+    <value>{0}이(가) 만들어졌습니다.</value>
+  </data>
+  <data name="Delegate_Definition" xml:space="preserve">
+    <value>위임자는 승인된 애플리케이션 사용자입니다. 여기에 정의한 사용자 또는 매핑된 권한이 있거나 자체 편집이 활성화된 다음 Active Directory 그룹(또는 중첩된 그룹)의 사용자만 해당됩니다.</value>
+  </data>
+  <data name="Delegate_Function" xml:space="preserve">
+    <value>각 위임자에게 허용되는 액세스는 매핑된 액세스 수준에 의해 제어됩니다.</value>
+  </data>
+  <data name="Deleted" xml:space="preserve">
+    <value>{0}이(가) 삭제되었습니다.</value>
+  </data>
+  <data name="Delete_API_Token_Confirmation" xml:space="preserve">
+    <value>이 API 토큰을 삭제하시겠습니까?</value>
+  </data>
+  <data name="Delete_Auth_Token_Confirmation" xml:space="preserve">
+    <value>Google Authenticator MFA를 비활성화하시겠습니까?</value>
+  </data>
+  <data name="Deny_Request_Confirmation" xml:space="preserve">
+    <value>이 요청을 거부하시겠습니까?</value>
+  </data>
+  <data name="Developer_Analytics_Suggestion" xml:space="preserve">
+    <value>앱 사용 방식을 이해하고 사용자가 가장 중요하다고 생각하는 부분에 노력을 집중할 수 있도록 개발자 분석을 허용해 주시기 바랍니다.</value>
+  </data>
+  <data name="Developer_Logs_Suggestion" xml:space="preserve">
+    <value>Blazam을 빠르고 투명하게 개선하고 개발 노력을 지원할 수 있도록 개발자 로깅을 허용해 주시기 바랍니다.</value>
+  </data>
+  <data name="Duplicate_Delegate" xml:space="preserve">
+    <value>해당 위임자가 이미 존재합니다.</value>
+  </data>
+  <data name="Duplicate_Deleted_Delegate" xml:space="preserve">
+    <value>해당 위임자가 이미 존재합니다. 삭제되었습니다. 휴지통에서 복원하십시오.</value>
+  </data>
+  <data name="Duplicate_Name_Conflict" xml:space="preserve">
+    <value>해당 이름이 이미 존재합니다. 다른 이름을 선택하십시오.</value>
+  </data>
+  <data name="GA4_Instructions" xml:space="preserve">
+    <value>GA4 계정을 설정하고 여기에 추적 ID를 입력하여 설치 사용량에 대한 데이터를 수집하십시오.</value>
+  </data>
+  <data name="Invalid_Cert_Type" xml:space="preserve">
+    <value>유효한 인증서 유형이 아닙니다.</value>
+  </data>
+  <data name="Invalid_Token_Entered" xml:space="preserve">
+    <value>입력한 토큰이 유효하지 않습니다.</value>
+  </data>
+  <data name="Lacks_Group_Member_Read_Permission" xml:space="preserve">
+    <value>그룹에 액세스할 수 없는 구성원이 더 있습니다.</value>
+  </data>
+  <data name="Lacks_Group_Member_Remove_Permission" xml:space="preserve">
+    <value>이 그룹 구성원을 제거할 권한이 없습니다.</value>
+  </data>
+  <data name="Locked_Out" xml:space="preserve">
+    <value>{0}이(가) 잠겼습니다.</value>
+  </data>
+  <data name="Mapping_Use_Access_Level" xml:space="preserve">
+    <value>{0} 매핑은 이 액세스 수준을 사용하며 삭제됩니다.</value>
+  </data>
+  <data name="Modify_Name_Redirect" xml:space="preserve">
+    <value>사용자 이름을 수정하려면 도구 모음/기어 메뉴에서 이름 바꾸기 버튼을 클릭하십시오.</value>
+  </data>
+  <data name="Navigate_Away_Confirmation" xml:space="preserve">
+    <value>나가시겠습니까?</value>
+  </data>
+  <data name="News_Provider_Description" xml:space="preserve">
+    <value>중요한 업데이트 및 변경 사항이 여기에 게시됩니다.</value>
+  </data>
+  <data name="No_More_Widgets" xml:space="preserve">
+    <value>추가할 위젯이 더 이상 없습니다.</value>
+  </data>
+  <data name="No_News" xml:space="preserve">
+    <value>여기에 새로운 소식이 없습니다.</value>
+  </data>
+  <data name="No_Request_Actions_Available" xml:space="preserve">
+    <value>이 항목에 대해 요청할 수 있는 작업이 없습니다.</value>
+  </data>
+  <data name="Overwrite_Auth_Token_Confirmation" xml:space="preserve">
+    <value>새 인증 토큰을 생성하면 기존 토큰이 무효화됩니다!</value>
+  </data>
+  <data name="Rearrange_Dashboard_Help" xml:space="preserve">
+    <value>항목을 새 위치로 끌어 대시보드 위젯 재정렬</value>
+  </data>
+  <data name="Rename_Reboot_Message" xml:space="preserve">
+    <value>관리자가 이 워크스테이션의 이름을 변경했습니다. {0}초 후에 재부팅됩니다.</value>
+  </data>
+  <data name="Request_To" xml:space="preserve">
+    <value>{0}에 요청</value>
+  </data>
+  <data name="Rule_No_Filter_Warning" xml:space="preserve">
+    <value>이 규칙은 {0}이(가) {1}일 때마다 실행됩니다.</value>
+  </data>
+  <data name="Stop_On_Rule" xml:space="preserve">
+    <value>더 이상 규칙을 처리하지 마십시오.</value>
+  </data>
+  <data name="Super_User_Definition" xml:space="preserve">
+    <value>활성화하면 애플리케이션에 대한 완전하고 총체적인 액세스 권한을 갖게 됩니다.</value>
+  </data>
+  <data name="Unexpected_Error_Occurred" xml:space="preserve">
+    <value>예기치 않은 오류가 발생했습니다.</value>
+  </data>
+  <data name="Upate_Branch_Definition" xml:space="preserve">
+    <value>릴리스 브랜치가 권장 브랜치입니다. Nightly 선택은 테스트 설치에만 권장됩니다. Dev는 개발자 전용입니다.</value>
+  </data>
+  <data name="Updated" xml:space="preserve">
+    <value>{0}이(가) 업데이트되었습니다.</value>
+  </data>
+  <data name="Update_Credential_Is_AD" xml:space="preserve">
+    <value>Active Directory 자격 증명이 업데이트를 위해 확인되었습니다.</value>
+  </data>
+  <data name="Update_Credential_Is_Application" xml:space="preserve">
+    <value>Blazam을 실행하는 계정은 애플리케이션 디렉터리에 쓸 수 있습니다.
+이렇게 하면 호스트 시스템이 불필요한 위험에 노출됩니다. 애플리케이션 ID를 변경하십시오.
+보안을 강화하려면 권한이 낮은 계정으로 변경하십시오.</value>
+  </data>
+  <data name="Update_Credential_Is_Custom" xml:space="preserve">
+    <value>사용자 지정 업데이트 자격 증명이 업데이트를 위해 확인되었습니다.</value>
+  </data>
+  <data name="Update_Credential_Is_Invalid" xml:space="preserve">
+    <value>애플리케이션 디렉터리에 대한 쓰기 권한이 있는 자격 증명이 구성되어 있지 않습니다!
+사용자 지정 업데이트 자격 증명을 구성해 보십시오.</value>
+  </data>
+</root>

--- a/BLAZAMLocalization/AppHelpLocalization.pl.resx
+++ b/BLAZAMLocalization/AppHelpLocalization.pl.resx
@@ -1,0 +1,267 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Access_Level_Definition" xml:space="preserve">
+    <value>Poziomy dostępu to szablon uprawnień, który można zastosować do określonych jednostek organizacyjnych dla określonych delegatów.</value>
+  </data>
+  <data name="Access_Level_Object_Missing_Read" xml:space="preserve">
+    <value>Zmień dostęp {0} na Odczyt, aby ustawić uprawnienia</value>
+  </data>
+  <data name="Authenticator_Setup_One" xml:space="preserve">
+    <value>Zeskanuj poniższy kod za pomocą aplikacji uwierzytelniającej</value>
+  </data>
+  <data name="Authenticator_Setup_Two" xml:space="preserve">
+    <value>Następnie wprowadź hasło, aby aktywować</value>
+  </data>
+  <data name="Auto_Update_Time_Definition" xml:space="preserve">
+    <value>Godzina każdego dnia, o której aktualizacja ma być automatycznie stosowana.</value>
+  </data>
+  <data name="Confirm_Group_Creation" xml:space="preserve">
+    <value>Czy na pewno chcesz utworzyć tę grupę?</value>
+  </data>
+  <data name="Confirm_OU_Creation" xml:space="preserve">
+    <value>Czy na pewno chcesz utworzyć tę jednostkę organizacyjną?</value>
+  </data>
+  <data name="Confirm_Save_Changes" xml:space="preserve">
+    <value>Czy na pewno chcesz zapisać zmiany?</value>
+  </data>
+  <data name="Continue_Processing_Rules" xml:space="preserve">
+    <value>Kontynuuj przetwarzanie innych reguł</value>
+  </data>
+  <data name="Created" xml:space="preserve">
+    <value>Utworzono {0}</value>
+  </data>
+  <data name="Delegate_Definition" xml:space="preserve">
+    <value>Delegaci to zatwierdzeni użytkownicy aplikacji. Tylko zdefiniowani tutaj użytkownicy lub użytkownicy w następujących grupach Active Directory (lub grupach zagnieżdżonych) z przypisanymi uprawnieniami lub włączoną samodzielną edycją.</value>
+  </data>
+  <data name="Delegate_Function" xml:space="preserve">
+    <value>Dostęp przyznany każdemu delegatowi jest kontrolowany przez przypisany poziom dostępu.</value>
+  </data>
+  <data name="Deleted" xml:space="preserve">
+    <value>Usunięto {0}</value>
+  </data>
+  <data name="Delete_API_Token_Confirmation" xml:space="preserve">
+    <value>Czy na pewno chcesz usunąć ten token API?</value>
+  </data>
+  <data name="Delete_Auth_Token_Confirmation" xml:space="preserve">
+    <value>Czy na pewno chcesz wyłączyć uwierzytelnianie wieloskładnikowe Google Authenticator?</value>
+  </data>
+  <data name="Deny_Request_Confirmation" xml:space="preserve">
+    <value>Czy na pewno chcesz odrzucić to żądanie?</value>
+  </data>
+  <data name="Developer_Analytics_Suggestion" xml:space="preserve">
+    <value>Prosimy o zezwolenie na analizę deweloperską, abyśmy mogli zrozumieć, w jaki sposób nasza aplikacja jest używana, i skoncentrować nasze wysiłki na tym, co nasi użytkownicy uważają za najważniejsze.</value>
+  </data>
+  <data name="Developer_Logs_Suggestion" xml:space="preserve">
+    <value>Prosimy o zezwolenie na rejestrowanie przez deweloperów, abyśmy mogli szybko i przejrzyście ulepszać Blazam oraz wspierać nasze wysiłki rozwojowe.</value>
+  </data>
+  <data name="Duplicate_Delegate" xml:space="preserve">
+    <value>Ten delegat już istnieje.</value>
+  </data>
+  <data name="Duplicate_Deleted_Delegate" xml:space="preserve">
+    <value>Ten delegat już istnieje. Został usunięty. Przywróć go z kosza.</value>
+  </data>
+  <data name="Duplicate_Name_Conflict" xml:space="preserve">
+    <value>Ta nazwa już istnieje. Wybierz inną nazwę</value>
+  </data>
+  <data name="GA4_Instructions" xml:space="preserve">
+    <value>Skonfiguruj konto GA4 i wprowadź tutaj swój identyfikator śledzenia, aby zbierać dane o użytkowaniu Twojej instalacji.</value>
+  </data>
+  <data name="Invalid_Cert_Type" xml:space="preserve">
+    <value>Nieprawidłowy typ certyfikatu.</value>
+  </data>
+  <data name="Invalid_Token_Entered" xml:space="preserve">
+    <value>Wprowadzony token jest nieprawidłowy</value>
+  </data>
+  <data name="Lacks_Group_Member_Read_Permission" xml:space="preserve">
+    <value>Grupa ma więcej członków, do których nie masz dostępu</value>
+  </data>
+  <data name="Lacks_Group_Member_Remove_Permission" xml:space="preserve">
+    <value>Nie masz uprawnień do usunięcia tego członka grupy</value>
+  </data>
+  <data name="Locked_Out" xml:space="preserve">
+    <value>Zablokowano {0}</value>
+  </data>
+  <data name="Mapping_Use_Access_Level" xml:space="preserve">
+    <value>Mapowania {0} używają tego poziomu dostępu i zostaną usunięte</value>
+  </data>
+  <data name="Modify_Name_Redirect" xml:space="preserve">
+    <value>Aby zmodyfikować nazwę użytkownika, kliknij przycisk Zmień nazwę na pasku narzędzi/w menu koła zębatego</value>
+  </data>
+  <data name="Navigate_Away_Confirmation" xml:space="preserve">
+    <value>Czy na pewno chcesz opuścić stronę?</value>
+  </data>
+  <data name="News_Provider_Description" xml:space="preserve">
+    <value>Ważne aktualizacje i zmiany są publikowane tutaj.</value>
+  </data>
+  <data name="No_More_Widgets" xml:space="preserve">
+    <value>Nie ma więcej widżetów do dodania</value>
+  </data>
+  <data name="No_News" xml:space="preserve">
+    <value>Nie ma tu nic nowego do zobaczenia</value>
+  </data>
+  <data name="No_Request_Actions_Available" xml:space="preserve">
+    <value>Dla tego wpisu nie są dostępne żadne działania do żądania.</value>
+  </data>
+  <data name="Overwrite_Auth_Token_Confirmation" xml:space="preserve">
+    <value>Wygenerowanie nowego tokenu uwierzytelniającego unieważni istniejący!</value>
+  </data>
+  <data name="Rearrange_Dashboard_Help" xml:space="preserve">
+    <value>Zmień kolejność widżetów pulpitu nawigacyjnego, przeciągając elementy na nową pozycję</value>
+  </data>
+  <data name="Rename_Reboot_Message" xml:space="preserve">
+    <value>Administrator zmienił nazwę tej stacji roboczej. Uruchomi się ponownie za {0} sekund.</value>
+  </data>
+  <data name="Request_To" xml:space="preserve">
+    <value>Żądanie do {0}</value>
+  </data>
+  <data name="Rule_No_Filter_Warning" xml:space="preserve">
+    <value>Ta reguła zostanie uruchomiona za każdym razem, gdy {0} to {1}</value>
+  </data>
+  <data name="Stop_On_Rule" xml:space="preserve">
+    <value>Nie przetwarzaj więcej reguł</value>
+  </data>
+  <data name="Super_User_Definition" xml:space="preserve">
+    <value>Po włączeniu będzie miał pełny i całkowity dostęp do aplikacji</value>
+  </data>
+  <data name="Unexpected_Error_Occurred" xml:space="preserve">
+    <value>Wystąpił nieoczekiwany błąd.</value>
+  </data>
+  <data name="Upate_Branch_Definition" xml:space="preserve">
+    <value>Gałąź wydania jest zalecaną gałęzią. Wybór Nightly jest zalecany tylko w przypadku instalacji testowych. Dev jest przeznaczony tylko dla deweloperów.</value>
+  </data>
+  <data name="Updated" xml:space="preserve">
+    <value>Zaktualizowano {0}</value>
+  </data>
+  <data name="Update_Credential_Is_AD" xml:space="preserve">
+    <value>Poświadczenia Active Directory są weryfikowane pod kątem aktualizacji.</value>
+  </data>
+  <data name="Update_Credential_Is_Application" xml:space="preserve">
+    <value>Konto, na którym działa Blazam, może zapisywać w katalogu aplikacji.
+Naraża to komputer hosta на niepotrzebne ryzyko. Zmień tożsamość aplikacji
+na konto o niższych uprawnieniach, aby poprawić bezpieczeństwo.</value>
+  </data>
+  <data name="Update_Credential_Is_Custom" xml:space="preserve">
+    <value>Niestandardowe poświadczenia aktualizacji są weryfikowane pod kątem aktualizacji.</value>
+  </data>
+  <data name="Update_Credential_Is_Invalid" xml:space="preserve">
+    <value>Brak skonfigurowanych poświadczeń z uprawnieniami do zapisu w katalogu aplikacji!
+Spróbuj skonfigurować niestandardowe poświadczenia aktualizacji.</value>
+  </data>
+</root>

--- a/BLAZAMLocalization/AppHelpLocalization.ru.resx
+++ b/BLAZAMLocalization/AppHelpLocalization.ru.resx
@@ -1,0 +1,267 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Access_Level_Definition" xml:space="preserve">
+    <value>Уровни доступа — это шаблон разрешений, который можно применять к определенным подразделениям для определенных делегатов.</value>
+  </data>
+  <data name="Access_Level_Object_Missing_Read" xml:space="preserve">
+    <value>Измените доступ {0} на Чтение, чтобы установить разрешения</value>
+  </data>
+  <data name="Authenticator_Setup_One" xml:space="preserve">
+    <value>Отсканируйте приведенный ниже код из приложения для аутентификации.</value>
+  </data>
+  <data name="Authenticator_Setup_Two" xml:space="preserve">
+    <value>Затем введите пароль для активации</value>
+  </data>
+  <data name="Auto_Update_Time_Definition" xml:space="preserve">
+    <value>Время каждого дня для автоматического применения обновления.</value>
+  </data>
+  <data name="Confirm_Group_Creation" xml:space="preserve">
+    <value>Вы уверены, что хотите создать эту группу?</value>
+  </data>
+  <data name="Confirm_OU_Creation" xml:space="preserve">
+    <value>Вы уверены, что хотите создать это подразделение?</value>
+  </data>
+  <data name="Confirm_Save_Changes" xml:space="preserve">
+    <value>Вы уверены, что хотите сохранить изменения?</value>
+  </data>
+  <data name="Continue_Processing_Rules" xml:space="preserve">
+    <value>Продолжить обработку других правил</value>
+  </data>
+  <data name="Created" xml:space="preserve">
+    <value>{0} создан</value>
+  </data>
+  <data name="Delegate_Definition" xml:space="preserve">
+    <value>Делегаты — это утвержденные пользователи приложения. Только пользователи, которых вы определяете здесь, или пользователи в следующих группах Active Directory (или вложенных группах) с сопоставленными разрешениями или включенным саморедактированием.</value>
+  </data>
+  <data name="Delegate_Function" xml:space="preserve">
+    <value>Доступ, разрешенный каждому делегату, контролируется сопоставленным уровнем доступа.</value>
+  </data>
+  <data name="Deleted" xml:space="preserve">
+    <value>{0} удален</value>
+  </data>
+  <data name="Delete_API_Token_Confirmation" xml:space="preserve">
+    <value>Вы уверены, что хотите удалить этот токен API?</value>
+  </data>
+  <data name="Delete_Auth_Token_Confirmation" xml:space="preserve">
+    <value>Вы уверены, что хотите отключить многофакторную аутентификацию Google Authenticator?</value>
+  </data>
+  <data name="Deny_Request_Confirmation" xml:space="preserve">
+    <value>Вы уверены, что хотите отклонить этот запрос?</value>
+  </data>
+  <data name="Developer_Analytics_Suggestion" xml:space="preserve">
+    <value>Мы просим вас разрешить аналитику для разработчиков, чтобы мы могли понять, как используется наше приложение, и сосредоточить наши усилия на том, что, по мнению наших пользователей, наиболее важно.</value>
+  </data>
+  <data name="Developer_Logs_Suggestion" xml:space="preserve">
+    <value>Мы просим вас разрешить ведение журналов для разработчиков, чтобы мы могли быстро и прозрачно улучшать Blazam и содействовать нашим усилиям по разработке.</value>
+  </data>
+  <data name="Duplicate_Delegate" xml:space="preserve">
+    <value>Этот делегат уже существует.</value>
+  </data>
+  <data name="Duplicate_Deleted_Delegate" xml:space="preserve">
+    <value>Этот делегат уже существует. Он был удален. Восстановите его из корзины.</value>
+  </data>
+  <data name="Duplicate_Name_Conflict" xml:space="preserve">
+    <value>Это имя уже существует. Пожалуйста, выберите другое имя</value>
+  </data>
+  <data name="GA4_Instructions" xml:space="preserve">
+    <value>Настройте учетную запись GA4 и введите здесь свой идентификатор отслеживания, чтобы собирать данные об использовании вашей установки.</value>
+  </data>
+  <data name="Invalid_Cert_Type" xml:space="preserve">
+    <value>Недопустимый тип сертификата.</value>
+  </data>
+  <data name="Invalid_Token_Entered" xml:space="preserve">
+    <value>Введенный токен недействителен</value>
+  </data>
+  <data name="Lacks_Group_Member_Read_Permission" xml:space="preserve">
+    <value>В группе есть другие участники, к которым у вас нет доступа</value>
+  </data>
+  <data name="Lacks_Group_Member_Remove_Permission" xml:space="preserve">
+    <value>У вас нет разрешения на удаление этого участника группы</value>
+  </data>
+  <data name="Locked_Out" xml:space="preserve">
+    <value>{0} заблокирован</value>
+  </data>
+  <data name="Mapping_Use_Access_Level" xml:space="preserve">
+    <value>Сопоставления {0} используют этот уровень доступа и будут удалены</value>
+  </data>
+  <data name="Modify_Name_Redirect" xml:space="preserve">
+    <value>Чтобы изменить имя пользователя, нажмите кнопку «Переименовать» на панели инструментов / в меню шестеренки.</value>
+  </data>
+  <data name="Navigate_Away_Confirmation" xml:space="preserve">
+    <value>Вы уверены, что хотите уйти?</value>
+  </data>
+  <data name="News_Provider_Description" xml:space="preserve">
+    <value>Важные обновления и изменения публикуются здесь.</value>
+  </data>
+  <data name="No_More_Widgets" xml:space="preserve">
+    <value>Больше нет виджетов для добавления</value>
+  </data>
+  <data name="No_News" xml:space="preserve">
+    <value>Здесь нет ничего нового</value>
+  </data>
+  <data name="No_Request_Actions_Available" xml:space="preserve">
+    <value>Для этой записи нет доступных действий для запроса.</value>
+  </data>
+  <data name="Overwrite_Auth_Token_Confirmation" xml:space="preserve">
+    <value>Создание нового токена аутентификации аннулирует существующий!</value>
+  </data>
+  <data name="Rearrange_Dashboard_Help" xml:space="preserve">
+    <value>Переупорядочивайте виджеты на панели мониторинга, перетаскивая элементы на новое место</value>
+  </data>
+  <data name="Rename_Reboot_Message" xml:space="preserve">
+    <value>Администратор переименовал эту рабочую станцию. Она перезагрузится через {0} секунд.</value>
+  </data>
+  <data name="Request_To" xml:space="preserve">
+    <value>Запрос к {0}</value>
+  </data>
+  <data name="Rule_No_Filter_Warning" xml:space="preserve">
+    <value>Это правило будет срабатывать каждый раз, когда {0} является {1}</value>
+  </data>
+  <data name="Stop_On_Rule" xml:space="preserve">
+    <value>Не обрабатывать больше никаких правил</value>
+  </data>
+  <data name="Super_User_Definition" xml:space="preserve">
+    <value>При включении будет иметь полный и неограниченный доступ к приложению.</value>
+  </data>
+  <data name="Unexpected_Error_Occurred" xml:space="preserve">
+    <value>Произошла непредвиденная ошибка.</value>
+  </data>
+  <data name="Upate_Branch_Definition" xml:space="preserve">
+    <value>Рекомендуемой веткой является ветка релиза. Выбор Nightly рекомендуется только для тестовых установок. Dev предназначен только для разработчиков.</value>
+  </data>
+  <data name="Updated" xml:space="preserve">
+    <value>{0} обновлен</value>
+  </data>
+  <data name="Update_Credential_Is_AD" xml:space="preserve">
+    <value>Учетные данные Active Directory проверены для обновления.</value>
+  </data>
+  <data name="Update_Credential_Is_Application" xml:space="preserve">
+    <value>Учетная запись, от имени которой выполняется Blazam, может выполнять запись в каталог приложения.
+Это подвергает хост-машину ненужному риску. Измените идентификатор приложения
+на учетную запись с более низкими привилегиями для повышения безопасности.</value>
+  </data>
+  <data name="Update_Credential_Is_Custom" xml:space="preserve">
+    <value>Пользовательские учетные данные для обновления проверены.</value>
+  </data>
+  <data name="Update_Credential_Is_Invalid" xml:space="preserve">
+    <value>Нет настроенных учетных данных с разрешением на запись в каталог приложения!
+Попробуйте настроить пользовательские учетные данные для обновления.</value>
+  </data>
+</root>

--- a/BLAZAMLocalization/AppHelpLocalization.zh-Hans.resx
+++ b/BLAZAMLocalization/AppHelpLocalization.zh-Hans.resx
@@ -1,0 +1,267 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Access_Level_Definition" xml:space="preserve">
+    <value>访问级别是可以应用于特定 OU 的特定委托的权限模板。</value>
+  </data>
+  <data name="Access_Level_Object_Missing_Read" xml:space="preserve">
+    <value>将 {0} 访问权限更改为读取以设置权限</value>
+  </data>
+  <data name="Authenticator_Setup_One" xml:space="preserve">
+    <value>从您的身份验证器应用程序扫描下面的代码</value>
+  </data>
+  <data name="Authenticator_Setup_Two" xml:space="preserve">
+    <value>然后输入密码以激活</value>
+  </data>
+  <data name="Auto_Update_Time_Definition" xml:space="preserve">
+    <value>每天自动应用更新的时间。</value>
+  </data>
+  <data name="Confirm_Group_Creation" xml:space="preserve">
+    <value>您确定要创建此组吗？</value>
+  </data>
+  <data name="Confirm_OU_Creation" xml:space="preserve">
+    <value>您确定要创建此 OU 吗？</value>
+  </data>
+  <data name="Confirm_Save_Changes" xml:space="preserve">
+    <value>您确定要保存更改吗？</value>
+  </data>
+  <data name="Continue_Processing_Rules" xml:space="preserve">
+    <value>继续处理其他规则</value>
+  </data>
+  <data name="Created" xml:space="preserve">
+    <value>已创建 {0}</value>
+  </data>
+  <data name="Delegate_Definition" xml:space="preserve">
+    <value>委托是您批准的应用程序用户。只有您在此处定义的用户，或以下 Active Directory 组（或嵌套组）中具有映射权限或启用自编辑的用户。</value>
+  </data>
+  <data name="Delegate_Function" xml:space="preserve">
+    <value>授予每个委托的访问权限由映射的访问级别控制。</value>
+  </data>
+  <data name="Deleted" xml:space="preserve">
+    <value>已删除 {0}</value>
+  </data>
+  <data name="Delete_API_Token_Confirmation" xml:space="preserve">
+    <value>您确定要删除此 API 令牌吗？</value>
+  </data>
+  <data name="Delete_Auth_Token_Confirmation" xml:space="preserve">
+    <value>您确定要禁用 Google Authenticator MFA 吗？</value>
+  </data>
+  <data name="Deny_Request_Confirmation" xml:space="preserve">
+    <value>您确定要拒绝此请求吗？</value>
+  </data>
+  <data name="Developer_Analytics_Suggestion" xml:space="preserve">
+    <value>我们要求您允许开发人员分析，以便我们了解我们的应用程序是如何使用的，从而将我们的工作重点放在我们的用户认为最重要的事情上。</value>
+  </data>
+  <data name="Developer_Logs_Suggestion" xml:space="preserve">
+    <value>我们要求您允许开发人员日志记录，以便我们可以快速透明地改进 Blazam 并帮助我们的开发工作。</value>
+  </data>
+  <data name="Duplicate_Delegate" xml:space="preserve">
+    <value>该委托已存在。</value>
+  </data>
+  <data name="Duplicate_Deleted_Delegate" xml:space="preserve">
+    <value>该委托已存在。它已被删除。从回收站恢复它。</value>
+  </data>
+  <data name="Duplicate_Name_Conflict" xml:space="preserve">
+    <value>该名称已存在。请选择其他名称</value>
+  </data>
+  <data name="GA4_Instructions" xml:space="preserve">
+    <value>设置 GA4 帐户并在此处输入您的跟踪 ID 以收集有关您安装使用情况的数据。</value>
+  </data>
+  <data name="Invalid_Cert_Type" xml:space="preserve">
+    <value>不是有效的证书类型。</value>
+  </data>
+  <data name="Invalid_Token_Entered" xml:space="preserve">
+    <value>输入的令牌无效</value>
+  </data>
+  <data name="Lacks_Group_Member_Read_Permission" xml:space="preserve">
+    <value>该组还有更多您无权访问的成员</value>
+  </data>
+  <data name="Lacks_Group_Member_Remove_Permission" xml:space="preserve">
+    <value>您无权删除此组成员</value>
+  </data>
+  <data name="Locked_Out" xml:space="preserve">
+    <value>已锁定 {0}</value>
+  </data>
+  <data name="Mapping_Use_Access_Level" xml:space="preserve">
+    <value>{0} 映射使用此访问级别并将被删除</value>
+  </data>
+  <data name="Modify_Name_Redirect" xml:space="preserve">
+    <value>要修改用户名，请单击工具栏/齿轮菜单中的重命名按钮</value>
+  </data>
+  <data name="Navigate_Away_Confirmation" xml:space="preserve">
+    <value>您确定要离开吗？</value>
+  </data>
+  <data name="News_Provider_Description" xml:space="preserve">
+    <value>重要更新和更改在此处发布。</value>
+  </data>
+  <data name="No_More_Widgets" xml:space="preserve">
+    <value>没有更多小部件可添加</value>
+  </data>
+  <data name="No_News" xml:space="preserve">
+    <value>这里没有什么新鲜事</value>
+  </data>
+  <data name="No_Request_Actions_Available" xml:space="preserve">
+    <value>此条目没有可请求的操作。</value>
+  </data>
+  <data name="Overwrite_Auth_Token_Confirmation" xml:space="preserve">
+    <value>生成新的身份验证器令牌将使现有令牌无效！</value>
+  </data>
+  <data name="Rearrange_Dashboard_Help" xml:space="preserve">
+    <value>通过将项目拖动到新位置来重新排列仪表板小部件</value>
+  </data>
+  <data name="Rename_Reboot_Message" xml:space="preserve">
+    <value>管理员已重命名此工作站。它将在 {0} 秒后重新启动。</value>
+  </data>
+  <data name="Request_To" xml:space="preserve">
+    <value>请求 {0}</value>
+  </data>
+  <data name="Rule_No_Filter_Warning" xml:space="preserve">
+    <value>每当 {0} 为 {1} 时，此规则就会触发</value>
+  </data>
+  <data name="Stop_On_Rule" xml:space="preserve">
+    <value>不要再处理任何规则</value>
+  </data>
+  <data name="Super_User_Definition" xml:space="preserve">
+    <value>如果启用，将拥有对应用程序的完全和全部访问权限</value>
+  </data>
+  <data name="Unexpected_Error_Occurred" xml:space="preserve">
+    <value>发生意外错误。</value>
+  </data>
+  <data name="Upate_Branch_Definition" xml:space="preserve">
+    <value>发布分支是推荐的分支。仅建议测试安装选择 Nightly。Dev 仅供开发人员使用。</value>
+  </data>
+  <data name="Updated" xml:space="preserve">
+    <value>已更新 {0}</value>
+  </data>
+  <data name="Update_Credential_Is_AD" xml:space="preserve">
+    <value>Active Directory 凭据已验证可用于更新。</value>
+  </data>
+  <data name="Update_Credential_Is_Application" xml:space="preserve">
+    <value>运行 Blazam 的帐户可以写入应用程序目录。
+这会使主机面临不必要的风险。更改应用程序标识
+为权限较低的帐户以提高安全性。</value>
+  </data>
+  <data name="Update_Credential_Is_Custom" xml:space="preserve">
+    <value>自定义更新凭据已验证可用于更新。</value>
+  </data>
+  <data name="Update_Credential_Is_Invalid" xml:space="preserve">
+    <value>没有配置具有应用程序目录写入权限的凭据！
+尝试配置自定义更新凭据。</value>
+  </data>
+</root>

--- a/BLAZAMLocalization/AppHelpLocalization.zh-Hant.resx
+++ b/BLAZAMLocalization/AppHelpLocalization.zh-Hant.resx
@@ -1,0 +1,267 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Access_Level_Definition" xml:space="preserve">
+    <value>存取層級是可套用至特定 OU 的特定委派的權限範本。</value>
+  </data>
+  <data name="Access_Level_Object_Missing_Read" xml:space="preserve">
+    <value>將 {0} 存取權限變更為讀取以設定權限</value>
+  </data>
+  <data name="Authenticator_Setup_One" xml:space="preserve">
+    <value>從您的驗證器應用程式掃描下面的代碼</value>
+  </data>
+  <data name="Authenticator_Setup_Two" xml:space="preserve">
+    <value>然後輸入密碼以啟動</value>
+  </data>
+  <data name="Auto_Update_Time_Definition" xml:space="preserve">
+    <value>每天自動套用更新的時間。</value>
+  </data>
+  <data name="Confirm_Group_Creation" xml:space="preserve">
+    <value>您確定要建立此群組嗎？</value>
+  </data>
+  <data name="Confirm_OU_Creation" xml:space="preserve">
+    <value>您確定要建立此 OU 嗎？</value>
+  </data>
+  <data name="Confirm_Save_Changes" xml:space="preserve">
+    <value>您確定要儲存變更嗎？</value>
+  </data>
+  <data name="Continue_Processing_Rules" xml:space="preserve">
+    <value>繼續處理其他規則</value>
+  </data>
+  <data name="Created" xml:space="preserve">
+    <value>已建立 {0}</value>
+  </data>
+  <data name="Delegate_Definition" xml:space="preserve">
+    <value>委派是您核准的應用程式使用者。只有您在此處定義的使用者，或下列 Active Directory 群組（或巢狀群組）中具有對應權限或啟用自我編輯的使用者。</value>
+  </data>
+  <data name="Delegate_Function" xml:space="preserve">
+    <value>授予每個委派的存取權限由對應的存取層級控制。</value>
+  </data>
+  <data name="Deleted" xml:space="preserve">
+    <value>已刪除 {0}</value>
+  </data>
+  <data name="Delete_API_Token_Confirmation" xml:space="preserve">
+    <value>您確定要刪除此 API 權杖嗎？</value>
+  </data>
+  <data name="Delete_Auth_Token_Confirmation" xml:space="preserve">
+    <value>您確定要停用 Google Authenticator MFA 嗎？</value>
+  </data>
+  <data name="Deny_Request_Confirmation" xml:space="preserve">
+    <value>您確定要拒絕此請求嗎？</value>
+  </data>
+  <data name="Developer_Analytics_Suggestion" xml:space="preserve">
+    <value>我們要求您允許開發人員分析，以便我們了解我們的應用程式是如何使用的，從而將我們的工作重點放在我們的使用者認為最重要的事情上。</value>
+  </data>
+  <data name="Developer_Logs_Suggestion" xml:space="preserve">
+    <value>我們要求您允許開發人員記錄，以便我們可以快速透明地改進 Blazam 並協助我們的開發工作。</value>
+  </data>
+  <data name="Duplicate_Delegate" xml:space="preserve">
+    <value>該委派已存在。</value>
+  </data>
+  <data name="Duplicate_Deleted_Delegate" xml:space="preserve">
+    <value>該委派已存在。它已被刪除。從資源回收筒還原它。</value>
+  </data>
+  <data name="Duplicate_Name_Conflict" xml:space="preserve">
+    <value>該名稱已存在。請選擇其他名稱</value>
+  </data>
+  <data name="GA4_Instructions" xml:space="preserve">
+    <value>設定 GA4 帳戶並在此處輸入您的追蹤 ID 以收集有關您安裝使用情況的資料。</value>
+  </data>
+  <data name="Invalid_Cert_Type" xml:space="preserve">
+    <value>不是有效的憑證類型。</value>
+  </data>
+  <data name="Invalid_Token_Entered" xml:space="preserve">
+    <value>輸入的權杖無效</value>
+  </data>
+  <data name="Lacks_Group_Member_Read_Permission" xml:space="preserve">
+    <value>該群組還有更多您無權存取的成員</value>
+  </data>
+  <data name="Lacks_Group_Member_Remove_Permission" xml:space="preserve">
+    <value>您無權移除此群組成員</value>
+  </data>
+  <data name="Locked_Out" xml:space="preserve">
+    <value>已鎖定 {0}</value>
+  </data>
+  <data name="Mapping_Use_Access_Level" xml:space="preserve">
+    <value>{0} 對應使用此存取層級並將被刪除</value>
+  </data>
+  <data name="Modify_Name_Redirect" xml:space="preserve">
+    <value>要修改使用者名稱，請按一下工具列/齒輪功能表中的重新命名按鈕</value>
+  </data>
+  <data name="Navigate_Away_Confirmation" xml:space="preserve">
+    <value>您確定要離開嗎？</value>
+  </data>
+  <data name="News_Provider_Description" xml:space="preserve">
+    <value>重要更新和變更會在此處發佈。</value>
+  </data>
+  <data name="No_More_Widgets" xml:space="preserve">
+    <value>沒有更多小工具可新增</value>
+  </data>
+  <data name="No_News" xml:space="preserve">
+    <value>這裡沒有什麼新鮮事</value>
+  </data>
+  <data name="No_Request_Actions_Available" xml:space="preserve">
+    <value>此項目沒有可請求的動作。</value>
+  </data>
+  <data name="Overwrite_Auth_Token_Confirmation" xml:space="preserve">
+    <value>產生新的驗證器權杖將使現有權杖失效！</value>
+  </data>
+  <data name="Rearrange_Dashboard_Help" xml:space="preserve">
+    <value>透過將項目拖曳到新位置來重新排列儀表板小工具</value>
+  </data>
+  <data name="Rename_Reboot_Message" xml:space="preserve">
+    <value>管理員已重新命名此工作站。它將在 {0} 秒後重新啟動。</value>
+  </data>
+  <data name="Request_To" xml:space="preserve">
+    <value>請求 {0}</value>
+  </data>
+  <data name="Rule_No_Filter_Warning" xml:space="preserve">
+    <value>每當 {0} 為 {1} 時，此規則就會觸發</value>
+  </data>
+  <data name="Stop_On_Rule" xml:space="preserve">
+    <value>不要再處理任何規則</value>
+  </data>
+  <data name="Super_User_Definition" xml:space="preserve">
+    <value>如果啟用，將擁有對應用程式的完整和全部存取權限</value>
+  </data>
+  <data name="Unexpected_Error_Occurred" xml:space="preserve">
+    <value>發生意外錯誤。</value>
+  </data>
+  <data name="Upate_Branch_Definition" xml:space="preserve">
+    <value>發行分支是建議的分支。僅建議測試安裝選擇 Nightly。Dev 僅供開發人員使用。</value>
+  </data>
+  <data name="Updated" xml:space="preserve">
+    <value>已更新 {0}</value>
+  </data>
+  <data name="Update_Credential_Is_AD" xml:space="preserve">
+    <value>Active Directory 認證已驗證可用于更新。</value>
+  </data>
+  <data name="Update_Credential_Is_Application" xml:space="preserve">
+    <value>執行 Blazam 的帳戶可以寫入應用程式目錄。
+這會使主機面臨不必要的風險。變更應用程式身分識別
+為權限較低的帳戶以提高安全性。</value>
+  </data>
+  <data name="Update_Credential_Is_Custom" xml:space="preserve">
+    <value>自訂更新認證已驗證可用于更新。</value>
+  </data>
+  <data name="Update_Credential_Is_Invalid" xml:space="preserve">
+    <value>沒有設定具有應用程式目錄寫入權限的認證！
+嘗試設定自訂更新認證。</value>
+  </data>
+</root>


### PR DESCRIPTION
Adds translated .resx files for AppHelpLocalization for the following languages:
- German (de)
- Spanish (es)
- French (fr)
- Hindi (hi)
- Italian (it)
- Japanese (ja)
- Korean (ko)
- Polish (pl)
- Russian (ru)
- Simplified Chinese (zh-Hans)
- Traditional Chinese (zh-Hant)

These files provide translations for UI help text and messages, making the application more accessible to users in these languages. The English AppHelpLocalization.resx was used as the source, and all keys have been maintained. Translations have been verified for completeness and structural integrity.