### PR TITLE
Fix potential integer underflow in LapsDecryptor

### DIFF
--- a/BLAZAMActiveDirectory/Data/LapsDecryptor.cs
+++ b/BLAZAMActiveDirectory/Data/LapsDecryptor.cs
@@ -62,6 +62,10 @@ namespace BLAZAM.ActiveDirectory.Data
 
         public string Decrypt(byte[] encryptedPass)
         {
+            if (encryptedPass.Length < 16)
+            {
+                throw new ArgumentException("Encrypted password data is too short.", nameof(encryptedPass));
+            }
             var tcs = new TaskCompletionSource<string>();
             GCHandle gch = GCHandle.Alloc(tcs);
 


### PR DESCRIPTION
Added a check to ensure the encrypted password length is at least 16 bytes. This prevents a potential integer underflow vulnerability that could lead to a buffer overflow when calling `NCryptUnprotectSecret` or an `ArgumentOutOfRangeException` from `Marshal.Copy`.