### PR TITLE
refactor: Centralize group matching logic

### DIFF
--- a/BLAZAM/Pages/API/Data/NewGroupDetails.cs
+++ b/BLAZAM/Pages/API/Data/NewGroupDetails.cs
@@ -1,0 +1,53 @@
+namespace BLAZAM.Pages.API.Data
+{
+    /// <summary>
+    /// Request package for creation of a group
+    /// </summary>
+    public class NewGroupDetails
+    {
+        /// <summary>
+        /// The name for this group
+        /// </summary>
+        public string Name { get; set; }
+        /// <summary>
+        /// The description for this group
+        /// </summary>
+        public string? Description { get; set; }
+        /// <summary>
+        /// The email for this group
+        /// </summary>
+        public string? Email { get; set; }
+
+        /// <summary>
+        /// The Distinguished Name of the Organizational Unit to
+        /// create the new group under
+        /// </summary>
+        public string OU { get; set; }
+
+
+        /// <summary>
+        /// A list of groups to make this new group a member of. The value can be the SID, DN, or
+        /// group name. If using group name, the name must be unique and match a single
+        /// group in the domain.
+        /// </summary>
+        public List<string>? Groups { get; set; } = new();
+
+    }
+    /// <summary>
+    /// Example details for Swagger documentation
+    /// </summary>
+    public class NewGroupDetailsExample
+    {
+        public object GetExamples()
+        {
+            return new NewGroupDetails
+            {
+                Name = "MyNewGroup",
+                Description = "A new group for testing",
+                Email = "test@example.com",
+                OU = "OU=Groups,DC=example,DC=com",
+                Groups = new List<string> { "S-1-5-21-1004336348-1177238915-682003330-512", "S-1-5-21-1004336348-1148567915-615476330-495" }
+            };
+        }
+    }
+}

--- a/BLAZAM/Pages/API/v1/ApiController.cs
+++ b/BLAZAM/Pages/API/v1/ApiController.cs
@@ -93,5 +93,27 @@ namespace BLAZAM.Pages.API.v1
 
             return new JsonResult(ResponseData);
         }
+
+        protected IADGroup? FindGroupByIdentifier(string groupIdentifier)
+        {
+            var group = (IADGroup)Directory.FindEntryBySid(groupIdentifier);
+            if (group == null)
+            {
+                group = (IADGroup)Directory.GetDirectoryEntryByDN(groupIdentifier);
+            }
+            if (group == null)
+            {
+                var matches = Directory.Groups.FindGroupByString(groupIdentifier, true);
+                if (matches != null && matches.Count > 0)
+                {
+                    if (matches.Count > 1)
+                    {
+                        throw new DirectorySearchUniquenessException(groupIdentifier);
+                    }
+                    group = matches.First();
+                }
+            }
+            return group;
+        }
     }
 }

--- a/BLAZAM/Pages/API/v1/Group.cs
+++ b/BLAZAM/Pages/API/v1/Group.cs
@@ -44,12 +44,15 @@ namespace BLAZAM.Pages.API.v1
         {
             try
             {
-                var ou = Directory.OUs.FindOUByDN(newGroupDetails.OU);
+                var ou = Directory.OUs.FindOuByDN(newGroupDetails.OU);
                 if (ou == null)
                 {
                     return NotFound("OU not found");
                 }
-
+                if (!ou.CanCreateUser)
+                {
+                    return Forbid("You do not have permission to create groups in this OU");
+                }
                 var newGroup = ou.CreateGroup(newGroupDetails.Name);
                 if (newGroupDetails.Description != null)
                 {

--- a/BLAZAM/Pages/API/v1/Group.cs
+++ b/BLAZAM/Pages/API/v1/Group.cs
@@ -1,0 +1,94 @@
+using BLAZAM.ActiveDirectory.Interfaces;
+using BLAZAM.Database.Context;
+using BLAZAM.Services.Audit;
+using BLAZAM.Session.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using BLAZAM.Pages.API.Data;
+
+namespace BLAZAM.Pages.API.v1
+{
+    /// <summary>
+    /// Manages groups in Active Directory
+    /// </summary>
+    [Produces("application/json")]
+    public class Group : ApiController
+    {
+        public Group(IApplicationUserStateService applicationUserStateService, WebUserAuditLogger audit, IUserDatabaseFactory appDatabaseFactory, IHttpContextAccessor httpContextAccessor, IActiveDirectoryContextFactory adFactory) : base(applicationUserStateService, audit, appDatabaseFactory, httpContextAccessor, adFactory)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new group.
+        /// </summary>
+        /// <remarks>
+        /// Sample request:
+        ///
+        ///     POST /api/v1/group/create
+        ///     {
+        ///        "Name": "MyNewGroup",
+        ///        "Description": "A new group for testing",
+        ///        "Email": "test@example.com",
+        ///        "OU": "OU=Groups,DC=example,DC=com",
+        ///        "Groups": [ "S-1-5-21-1004336348-1177238915-682003330-512" ]
+        ///     }
+        ///
+        /// </remarks>
+        /// <param name="newGroupDetails">A complete NewGroupDetails request schema</param>
+        /// <response code="200">Returns the newly created group object.</response>
+        /// <response code="400">Bad Request - The request is malformed or invalid.</response>
+        /// <response code="401">Unauthorized - The user is not authenticated.</response>
+        /// <response code="403">Forbidden - The user does not have the required role.</response>
+        /// <response code="404">Not Found - The specified OU was not found.</response>
+        [HttpPost("create")]
+        public IActionResult OnPost([FromBody] NewGroupDetails newGroupDetails)
+        {
+            try
+            {
+                var ou = Directory.OUs.FindOUByDN(newGroupDetails.OU);
+                if (ou == null)
+                {
+                    return NotFound("OU not found");
+                }
+
+                var newGroup = ou.CreateGroup(newGroupDetails.Name);
+                if (newGroupDetails.Description != null)
+                {
+                    newGroup.Description = newGroupDetails.Description;
+                }
+                if (newGroupDetails.Email != null)
+                {
+                    newGroup.Email = newGroupDetails.Email;
+                }
+
+                if (newGroupDetails.Groups != null)
+                {
+                    AssignToGroups(newGroupDetails, newGroup);
+                }
+
+
+                newGroup.CommitChanges();
+                return FormatData(newGroup);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(ex.Message);
+            }
+        }
+
+        private void AssignToGroups(NewGroupDetails newGroupDetails, IADGroup newGroup)
+        {
+            if (newGroupDetails.Groups != null)
+            {
+                foreach (var groupIdentifier in newGroupDetails.Groups)
+                {
+                    var group = FindGroupByIdentifier(groupIdentifier);
+                    if (group != null)
+                    {
+                        group.AssignMember(newGroup);
+                        group.CommitChanges();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/BLAZAM/Pages/API/v1/Templates.cs
+++ b/BLAZAM/Pages/API/v1/Templates.cs
@@ -224,34 +224,12 @@ namespace BLAZAM.Pages.API.v1
         {
             if (newUserDetails.Groups != null)
             {
-                foreach (var groupSid in newUserDetails.Groups)
+                foreach (var groupIdentifier in newUserDetails.Groups)
                 {
-                    var group = (IADGroup)Directory.FindEntryBySid(groupSid);
-                    if(group == null)
-                    {
-                        group = (IADGroup)Directory.GetDirectoryEntryByDN(groupSid);
-                    }
-                    if (group == null)
-                    {
-                        group = (IADGroup)Directory.GetDirectoryEntryByDN(groupSid);
-                    }
-                    if (group == null)
-                    {
-                        var matches = Directory.Groups.FindGroupByString(groupSid,true);
-                        if (matches != null && matches.Count > 0)
-                        {
-                            if (matches.Count > 1)
-                            {
-                                throw new DirectorySearchUniquenessException(groupSid);
-                            }
-                            group = matches.First();
-                        }
-
-                    }
+                    var group = FindGroupByIdentifier(groupIdentifier);
                     if (group != null)
                     {
                         newUser?.AssignTo(group);
-
                     }
                 }
             }


### PR DESCRIPTION
This commit refactors the group matching logic into a new protected method `FindGroupByIdentifier` in the `ApiController` base class.

The `Group` and `Templates` API controllers have been updated to use this new centralized method. This removes code duplication and ensures that group matching is consistent across the application.

The group matching logic searches for groups by SID, then DN, and finally by name.