### PR TITLE
Refactor GetAuthenticationCookie method and tests

### DIFF
--- a/BLAZAM.Tests/Session/SessionHelpersTests.cs
+++ b/BLAZAM.Tests/Session/SessionHelpersTests.cs
@@ -75,15 +75,9 @@ namespace BLAZAM.Tests.Session
         public void GetAuthenticationCookie_ReturnsNull_WhenNoCookie()
         {
             var context = new DefaultHttpContext();
-            var method = typeof(SessionHelpers)
-                .GetMethod("GetAuthenticationCookie", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-            Assert.NotNull(method); // Ensure method is found before invoking
-            if (method != null)
-            {
-                var result = method?.Invoke(null, new object[] { context });
-                Assert.Null(result);
-            }
-            throw new Exception("GetAuthenticationCookie method not found");
+
+            var result = context.GetAuthenticationCookie();
+            Assert.Null(result);
         }
     }
 }

--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.4.6</AssemblyVersion>
-		<Version>2025.08.18.2300</Version>
+		<Version>2025.08.18.2329</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMSession/Helpers/SessionHelpers.cs
+++ b/BLAZAMSession/Helpers/SessionHelpers.cs
@@ -130,7 +130,7 @@ namespace BLAZAM.Helpers
         /// <summary>
         /// Gets the ASP.NET Core authentication cookie value from the HttpContext.
         /// </summary>
-        private static string? GetAuthenticationCookie(this HttpContext httpContext)
+        public static string? GetAuthenticationCookie(this HttpContext httpContext)
         {
             // Get the current authentication cookie
             return httpContext.Request.Cookies[CookieAuthenticationDefaults.CookiePrefix + CookieAuthenticationDefaults.AuthenticationScheme];


### PR DESCRIPTION
- Changed GetAuthenticationCookie from private to public for improved accessibility.
- Simplified unit tests by removing reflection and directly calling the method.
- Updated project version from 2025.08.18.2300 to 2025.08.18.2329.