### PR TITLE
Add UpdateTempDirectory initialization in ApplicationUpdate

### DIFF
--- a/BLAZAMUpdate/ApplicationUpdate.cs
+++ b/BLAZAMUpdate/ApplicationUpdate.cs
@@ -134,6 +134,7 @@ namespace BLAZAM.Update
             _runningProcess = applicationInfo.RunningProcess;
             _runningVersion = applicationInfo.RunningVersion;
             _applicationRootDirectory = applicationInfo.ApplicationRoot;
+            UpdateTempDirectory = new SystemDirectory(applicationInfo.TempDirectory + $"update{Path.DirectorySeparatorChar}");
         }
 
         /// <summary>


### PR DESCRIPTION
This commit introduces a new initialization for the `UpdateTempDirectory` in the constructor of the `ApplicationUpdate` class. The `UpdateTempDirectory` is set to a new `SystemDirectory` object, which is constructed using the `TempDirectory` from `applicationInfo`, appending "update" and the appropriate directory separator for the operating system.