### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/analyze-code.yml
+++ b/.github/workflows/analyze-code.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     name: Build and analyze
+    permissions:
+      contents: read
     runs-on: windows-latest
     steps:
       - name: Set up JDK 17


### PR DESCRIPTION
Potential fix for [https://github.com/Blazam-App/BLAZAM/security/code-scanning/8](https://github.com/Blazam-App/BLAZAM/security/code-scanning/8)

To fix the problem, an explicit `permissions` block should be added to limit the GitHub Actions job's access token privileges, as recommended by the principle of least privilege. The simplest and most effective fix is to add a `permissions: contents: read` block, either at the top (to apply to the whole workflow), or at the job level (under `jobs.build`). Since the CodeQL highlight is on the job, we will add it to the `build` job. This will restrict the `GITHUB_TOKEN` granted to the workflow to only read repository contents, preventing unnecessary write access. No other code or functional changes are needed, and this change is done by editing lines in `.github/workflows/analyze-code.yml` directly under the job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
