### PR TITLE
Remove disabled fields from template user creation wizard

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.4.6</AssemblyVersion>
-		<Version>2025.09.01.2300</Version>
+		<Version>2025.09.01.2308</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMActiveDirectory/Helpers/ActiveDirectoryHelpers.cs
+++ b/BLAZAMActiveDirectory/Helpers/ActiveDirectoryHelpers.cs
@@ -104,7 +104,7 @@ namespace BLAZAM.Helpers
         /// <param name="newUserName">The new user's name details</param>
         public static void PopulateFields(this DirectoryTemplate template, IADUser user, NewUserName newUserName)
         {
-            foreach (var fieldValue in template.EffectiveFieldValues)
+            foreach (var fieldValue in template.EffectiveFieldValues.Where(fv => fv.DeletedAt == null))
             {
                 try
                 {

--- a/BLAZAMDatabase/Models/Templates/DirectoryTemplateFieldValue.cs
+++ b/BLAZAMDatabase/Models/Templates/DirectoryTemplateFieldValue.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
-using BLAZAM.Database.Interfaces;
 
 namespace BLAZAM.Database.Models.Templates
 {
@@ -61,5 +60,34 @@ namespace BLAZAM.Database.Models.Templates
         {
             return FieldDisplayName.GetHashCode();
         }
+        [NotMapped]
+        public DateTime? DeletedAt
+        {
+            get
+            {
+                if (Field != null)
+                {
+                    return Field.DeletedAt;
+                }
+                else if (CustomField != null)
+                {
+                    return CustomField.DeletedAt;
+                }
+                return null;
+            }
+            set
+            {
+                if (Field != null)
+                {
+                    Field.DeletedAt = value;
+                }
+
+                else if (CustomField != null)
+                {
+                    CustomField.DeletedAt = value;
+                }
+            }
+        }
+
     }
 }

--- a/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor
+++ b/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor
@@ -283,7 +283,7 @@
 
 
                             <MudStack Class="d-flex justify-center align-center mud-height-full">
-                                <MudDataGrid Items="@DirectoryTemplate.EffectiveFieldValues.Where(fv=>(fv.Field!=null &&  fv.Field.DeletedAt==null)||(fv.CustomField !=null && fv.CustomField.DeletedAt == null)).OrderBy(fv => fv.FieldDisplayName)"
+                                <MudDataGrid Items="@DirectoryTemplate.EffectiveFieldValues.Where(fv=>fv.DeletedAt==null).OrderBy(fv => fv.FieldDisplayName)"
                                              Dense=true
                                              Striped=true
                                              Bordered=true

--- a/BLAZAMGui/UI/Users/NewTemplateUser.razor
+++ b/BLAZAMGui/UI/Users/NewTemplateUser.razor
@@ -311,7 +311,7 @@
             @if (Entry.CanReadAnyCustomFields)
             {
                 <ViewSection Title=@AppLocalization[Lang.Additional_Fields]>
-                    @foreach (var field in DirectoryTemplate.EffectiveFieldValues.Where(f => f.CustomField != null))
+                    @foreach (var field in DirectoryTemplate.EffectiveFieldValues.Where(f => f.CustomField != null && f.DeletedAt==null))
                     {
                         @if (field.CustomField != null)
                         {


### PR DESCRIPTION
- Bump version in BLAZAM.csproj to 2025.09.01.2308.
- Modify PopulateFields to exclude deleted field values.
- Remove unused using directive in DirectoryTemplateFieldValue.cs.
- Add DeletedAt property to DirectoryTemplateFieldValue class.
- Update MudDataGrid in EditDirectoryTemplate.razor to filter out deleted values.
- Adjust foreach loop in NewTemplateUser.razor for custom fields to exclude deleted ones.