### PR TITLE
Unsubscribe from ViewersChanged in Dispose method

### DIFF
--- a/BLAZAMGui/UI/Chat/EntrySpecificChat.razor
+++ b/BLAZAMGui/UI/Chat/EntrySpecificChat.razor
@@ -127,7 +127,7 @@
     {
         base.Dispose();
 
-        ViewersChanged.Delegate += Refresh;
+        ViewersChanged.Delegate -= Refresh;
     }
     private void AddThisViewer()
     {


### PR DESCRIPTION
Updated the `Dispose` method in `EntrySpecificChat.razor` to unsubscribe the `Refresh` method from the `ViewersChanged.Delegate` event, preventing potential memory leaks and ensuring proper cleanup when the component is disposed.