### PR TITLE
Implement Group Rename

### DIFF
--- a/BLAZAMActiveDirectory/Adapters/ADGroup.cs
+++ b/BLAZAMActiveDirectory/Adapters/ADGroup.cs
@@ -131,12 +131,6 @@ namespace BLAZAM.ActiveDirectory.Adapters
             }
         }
 
-        public override bool Rename(string newName)
-        {
-            SAMAccountName = newName;
-            CommitChanges();
-            return base.Rename(newName);
-        }
 
         public override List<AuditChangeLog> Changes
         {

--- a/BLAZAMGui/UI/Groups/RenameGroupModalContent.razor
+++ b/BLAZAMGui/UI/Groups/RenameGroupModalContent.razor
@@ -1,53 +1,79 @@
 ﻿@inherits AppModalContent
 
-        @if (Group.CanEditField(ActiveDirectoryFields.SAMAccountName))
-        {
+@if (Group.CanEditField(ActiveDirectoryFields.SAMAccountName))
+{
 
 
-        <MudTextField AutoFocus=true Label="@AppLocalization[Lang.Group_Name]" @bind-Value="@GroupName" />
+    <MudTextField AutoFocus=true Label="@AppLocalization[Lang.Group_Name]" @bind-Value="@_privateEntryInstance.GroupName" />
 
-                
-            
-        }
 
-      
 
-    @if (Group.CanEditField(ActiveDirectoryFields.Mail))
-    {
-        
+}
 
-                <MudTextField Label="@AppLocalization[Lang.Email_Address]" @bind-Value="@Group.Email" />
 
-            
-        
-    }
 
-    <MudButton Color=Color.Primary OnClick="SaveChanges">@AppLocalization[Lang.Save_Changes]</MudButton>
+@if (Group.CanEditField(ActiveDirectoryFields.Mail))
+{
+
+
+    <MudTextField Label="@AppLocalization[Lang.Email_Address]" @bind-Value="@_privateEntryInstance.Email" />
+
+
+
+}
+
 
 @code {
-    
+
+
+    [Parameter]
+    public EventCallback<IDirectoryEntryAdapter> DirectoryModelRenamed { get; set; }
+
+    private IADGroup _privateEntryInstance;
+
     string GroupName;
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
+        Modal.SetOnYes(SaveChanges);
         GroupName = Group.CanonicalName;
+        if (Group != null)
+        {
+            _privateEntryInstance = Directory.Groups.FindGroupBySID(Group.SID.ToSidString());
+        }
         await StateHasChangedAsync();
+
     }
 
 
-     void SaveChanges()
+    async Task SaveChanges()
     {
-        if(GroupName.IsNullOrEmpty()){
-            SnackBarService.Warning("You must provide a group name");
-            GroupName = Group.CanonicalName;
-        }
-        try{
-            Group.Rename(GroupName);
-            SnackBarService.Success("The group has been renamed.");
-            
+        try
+        {
+
+            if (GroupName.IsNullOrEmpty())
+            {
+                SnackBarService.Warning("You must provide a group name");
+                return;
+            }
+
+            SaveDisabled = true;
+            LoadingData = true;
+            _privateEntryInstance.Rename(_privateEntryInstance.GroupName);
+
+            await _privateEntryInstance.CommitChangesAsync();
+            SnackBarService.Success("Group has been renamed.");
+            Group.DirectoryEntry = null;
+
+            await DirectoryModelRenamed.InvokeAsync(_privateEntryInstance);
             Close();
+
+            LoadingData = false;
+
+            SaveDisabled = false;
+
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             Loggers.ActiveDirectoryLogger.Error(ex, "Error attempting to rename a group");
             SnackBarService.Error("The group could not be renamed.");

--- a/BLAZAMGui/UI/Groups/ViewGroup.razor
+++ b/BLAZAMGui/UI/Groups/ViewGroup.razor
@@ -43,7 +43,7 @@
         <AppModal Title=@AppLocalization[Lang.Rename_Group] @ref=@RenameModal>
             @if (RenameModal?.IsShown == true)
             {
-                <RenameGroupModalContent Group="Group" />
+                <RenameGroupModalContent Group="Group" DirectoryModelRenamed=@((renamedGroup) => { Renamed(null, renamedGroup); }) />
             }
         </AppModal>
 
@@ -61,12 +61,12 @@
                         <MudIcon Style="height:150px;min-width:150px;" Icon="@Icons.Material.Filled.Group" />
                     </MudCard>
                     <DynamicMudInput Label="@AppLocalization[Lang.Group_Name]"
-                                     @bind-Value="@Group.CanonicalName"
+                                     @bind-Value="@Group.GroupName"
                                      Disabled=true />
-
+@* 
                     <DynamicMudInput Label="@AppLocalization[Lang.Account_Name]"
                                      @bind-Value="@Group.SAMAccountName"
-                                     Disabled=true />
+                                     Disabled=true /> *@
 
                     <DynamicMudInput Label="@AppLocalization[Lang.Description]"
                                      @bind-Value="@Group.Description"


### PR DESCRIPTION
Removed the `Rename` method from `ADGroup.cs` and implemented asynchronous renaming in `RenameGroupModalContent.razor` using a private instance of `IADGroup`. Updated bindings for group name and email fields to reflect the new structure. Enhanced the `SaveChanges` method with validation and added a callback for renaming events in `ViewGroup.razor`. Adjusted `DynamicMudInput` to use the correct group name binding.