### PR TITLE
Refine member count logic and update project version

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.4.9</AssemblyVersion>
-		<Version>2025.10.15.2217</Version>
+		<Version>2025.10.16.0949</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMGui/UI/Groups/GroupDirectMemberCounts.razor
+++ b/BLAZAMGui/UI/Groups/GroupDirectMemberCounts.razor
@@ -33,11 +33,11 @@
         @AppLocalization[Lang.Printers]: @Members.Count(m => m is IADPrinter)
     </MudText>
 }
-@if (Members.Any(m => m is IADContact))
+@if (Members.Any(m => m is IADContact && m is not IADUser))
 {
 
     <MudText Align="Align.End" Typo="Typo.body2">
-        @AppLocalization[Lang.Contacts]: @Members.Count(m => m is IADContact)
+        @AppLocalization[Lang.Contacts]: @Members.Count(m => m is IADContact && m is not IADUser)
     </MudText>
 }
 @if (Members.Count(m => !m.CanRead) > 0)

--- a/BLAZAMGui/UI/Groups/GroupNestedMemberCounts.razor
+++ b/BLAZAMGui/UI/Groups/GroupNestedMemberCounts.razor
@@ -42,11 +42,11 @@ else
             @AppLocalization[Lang.Printers]: @Members.Count(m => m is IADPrinter)
         </MudText>
     }
-    @if (Members.Any(m => m is IADContact))
+    @if (Members.Any(m => m is IADContact && m is not IADUser))
     {
 
         <MudText Align="Align.End" Typo="Typo.body2">
-            @AppLocalization[Lang.Contacts]: @Members.Count(m => m is IADContact)
+            @AppLocalization[Lang.Contacts]: @Members.Count(m => m is IADContact && m is not IADUser)
         </MudText>
     }
 }


### PR DESCRIPTION
Updated the `<Version>` property in `BLAZAM.csproj` to reflect a new build version (`2025.10.16.0949`).

Refined conditional logic in `GroupDirectMemberCounts.razor` and `GroupNestedMemberCounts.razor` to exclude `IADContact` members that are also `IADUser` from the count and display. This ensures accurate representation of `IADContact` members and addresses potential logic inconsistencies.