### PR TITLE
Fix for add group members returning all users

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.4.9</AssemblyVersion>
-		<Version>2025.10.16.0949</Version>
+		<Version>2025.10.17.1844</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMActiveDirectory/Adapters/ADGroup.cs
+++ b/BLAZAMActiveDirectory/Adapters/ADGroup.cs
@@ -198,15 +198,12 @@ namespace BLAZAM.ActiveDirectory.Adapters
             MembersToRemove = new();
             MembersToAdd = new();
             //CachedChildren = new List<IDirectoryEntryAdapter>();
-            _groupMembersCache = new List<IADGroup>();
-            _userMembersCache = new();
             base.DiscardChanges();
             OnModelChanged?.Invoke();
 
         }
         public bool HasMembers => UserMembers.Count > 0 || GroupMembers.Count > 0;
 
-        private List<IADUser> _userMembersCache;
 
         /// <summary>
         /// The members of this group, that are users themselves
@@ -216,26 +213,10 @@ namespace BLAZAM.ActiveDirectory.Adapters
         {
             get
             {
-                if (_userMembersCache == null)
-                {
-                    _userMembersCache = Directory.Groups.GetDirectUserMembers(this);
-                }
-                var temp = new List<IADUser>(_userMembersCache);
-                temp.AddRange(MembersToAdd.Where(m => m.Member is IADUser).Select(m => m.Member).Cast<IADUser>());
-
-                MembersToRemove.ForEach(u =>
-                {
-                    if (u.Member is IADUser user)
-                    {
-                        temp.Remove(user);
-                    }
-                });
-                temp = temp.OrderBy(u => u.CanonicalName).ToList();
-                return temp;
+                return Members.Where(m => m is IADUser).Cast<IADUser>().ToList();
             }
         }
 
-        private List<IADGroup> _groupMembersCache;
         /// <summary>
         /// The members of this group, that are groups themselves
         /// </summary>
@@ -244,23 +225,7 @@ namespace BLAZAM.ActiveDirectory.Adapters
         {
             get
             {
-                if (_groupMembersCache == null)
-                {
-                    _groupMembersCache = Directory.Groups.GetGroupMembers(this);
-                }
-                var temp = new List<IADGroup>(_groupMembersCache);
-                temp.AddRange(MembersToAdd.Where(m => m.Member is IADGroup).Select(m => m.Member).Cast<IADGroup>());
-
-                MembersToRemove.ForEach(u =>
-                {
-                    if (u.Member is IADGroup group)
-                    {
-                        temp.Remove(group);
-                    }
-                });
-
-                temp = temp.OrderBy(u => u.CanonicalName).ToList();
-                return temp;
+                return Members.Where(m => m is IADGroup).Cast<IADGroup>().ToList();
             }
         }
         public List<string>? MembersAsStrings


### PR DESCRIPTION
Updated `BLAZAM.csproj` to reflect a new build version (2025.10.17.1844). Refactored `UserMembers` and `GroupMembers` properties in `ADGroup.cs` to remove caching logic and streamline member filtering. The new implementation dynamically filters the `Members` collection for `IADUser` and `IADGroup` types, improving code clarity and maintainability.