### PR TITLE
Fix no permissions for non-admins after Duo authentication

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -5,7 +5,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
-		<AssemblyVersion>1.4.10</AssemblyVersion>
+		<AssemblyVersion>1.4.11</AssemblyVersion>
 		<Version>2025.10.27.1634</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>

--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.4.10</AssemblyVersion>
-		<Version>2025.10.24.1800</Version>
+		<Version>2025.10.27.1634</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.4.11</AssemblyVersion>
-		<Version>2025.10.27.1634</Version>
+		<Version>2025.10.27.1707</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMActiveDirectory/Adapters/ADGroup.cs
+++ b/BLAZAMActiveDirectory/Adapters/ADGroup.cs
@@ -263,6 +263,7 @@ namespace BLAZAM.ActiveDirectory.Adapters
 
             ADSearch search = new(Directory);
             search.Fields.NestedMemberOf = this;
+            search.EnabledOnly = false;
             var result = await search.SearchAsync<GroupableDirectoryAdapter, IGroupableDirectoryAdapter>();
             return result;
 
@@ -284,6 +285,7 @@ namespace BLAZAM.ActiveDirectory.Adapters
                 {
                     search.Results.Clear();
                     search.Fields.DN = t;
+                    search.EnabledOnly = false;
                     var member = search.Search<GroupableDirectoryAdapter, IGroupableDirectoryAdapter>()?.FirstOrDefault();
                     if (member != null)
                     {

--- a/BLAZAMSession/ApplicationUserStateService.cs
+++ b/BLAZAMSession/ApplicationUserStateService.cs
@@ -186,7 +186,10 @@ namespace BLAZAM.Session
             if (clonedPrincipal != null)
             {
                 // Create a fresh ApplicationUserState with the cloned principal so the queued MFARequest keeps a stable principal
+                var oldState = state;
                 state = CreateUserState(clonedPrincipal);
+                state.PermissionDelegates.AddRange(oldState.PermissionDelegates);
+                state.PermissionMappings.AddRange(oldState.PermissionMappings);
             }
             Loggers.SystemLogger.Information("ApplicationUserStateService.SetMFAUserState: Adding MFA request to queue for UserGUID {UserGUID}, MFAToken (hash): {MFATokenHash}.", state?.User?.FindFirstValue(ClaimTypes.Sid) ?? "Unknown", mfaToken?.GetAppHashCode().ToString() ?? "N/A");
             MFARequest mfaRequest = new(mfaType, mfaToken, returnURL, state);


### PR DESCRIPTION
Updated the project version in `BLAZAM.csproj` to 2025.10.27.1634. In `ApplicationUserStateService.cs`, improved the handling of `ApplicationUserState` by retaining `PermissionDelegates` and `PermissionMappings` from the old state when a `clonedPrincipal` is present.

Fixes #1264