### PR TITLE
Rename AllowAccessRequest to AllowActionAccessRequest

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.4.12</AssemblyVersion>
-		<Version>2025.12.13.1514</Version>
+		<Version>2025.12.13.1756</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMDatabase/Models/Permissions/GlobalPermissionSettings.cs
+++ b/BLAZAMDatabase/Models/Permissions/GlobalPermissionSettings.cs
@@ -4,7 +4,7 @@
     {
         public bool AllowSelfModification { get; set; }
 
-        public bool AllowAccessRequest { get; set; }
+        public bool AllowActionAccessRequest { get; set; }
 
     }
 }

--- a/BLAZAMGui/UI/DirectoryEntryViewHeader.razor.cs
+++ b/BLAZAMGui/UI/DirectoryEntryViewHeader.razor.cs
@@ -62,7 +62,7 @@ namespace BLAZAM.Gui.UI
             await base.OnInitializedAsync();
             LoadingData = true;
 
-            _showRequestButton = (await Context.GlobalPermissionSettings.FirstOrDefaultAsync())?.AllowAccessRequest == true
+            _showRequestButton = (await Context.GlobalPermissionSettings.FirstOrDefaultAsync())?.AllowActionAccessRequest == true
             && await Context.GlobalPermissionRequestActions.CountAsync() > 0;
             LoadingData = false;
 

--- a/BLAZAMGui/UI/Settings/Permissions/GlobalPermissions.razor
+++ b/BLAZAMGui/UI/Settings/Permissions/GlobalPermissions.razor
@@ -5,13 +5,13 @@
 
         <SettingsField Label="@AppLocalization[Lang.Allow_access_requests]">
 
-            <MudSwitch @bind-Value=settings.AllowAccessRequest
+            <MudSwitch @bind-Value=settings.AllowActionAccessRequest
                        T=bool
                        Class="mt-0"
                        Color="Color.Success"
                        Label=@AppLocalization[Lang.Allow_access_requests] />
         </SettingsField>
-        @if (settings.AllowAccessRequest)
+        @if (settings.AllowActionAccessRequest)
         {
             <SettingsField Label="@AppLocalization[Lang.Actions]">
 
@@ -102,7 +102,7 @@
     private async Task AddAction(ActiveDirectoryObjectAction action)
     {
 
-        if (settings.AllowAccessRequest)
+        if (settings.AllowActionAccessRequest)
         {
             if (!await Context.GlobalPermissionRequestActions.AnyAsync(x => x.ObjectAction == action))
             {


### PR DESCRIPTION
Renamed the AllowAccessRequest property to AllowActionAccessRequest in GlobalPermissionSettings and updated all related references in the UI and logic. Updated bindings and conditional checks in GlobalPermissions.razor and DirectoryEntryViewHeader.razor.cs. Bumped project version to 2025.12.13.1756.