### PR TITLE
Add username incrementor variables to templates

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.4.11</AssemblyVersion>
-		<Version>2025.12.27.1514</Version>
+		<Version>2025.12.27.1543</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.4.11</AssemblyVersion>
-		<Version>2025.12.27.0100</Version>
+		<Version>2025.12.27.1514</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMDatabase/Models/Templates/DirectoryTemplate.cs
+++ b/BLAZAMDatabase/Models/Templates/DirectoryTemplate.cs
@@ -17,7 +17,8 @@ namespace BLAZAM.Database.Models.Templates
     [Index(nameof(Name), IsUnique = true)]
     public class DirectoryTemplate : RecoverableAppDbSetBase
     {
-
+        private Regex variableSearch = new Regex(@"\{(?<var>[\w#\.\- ]+)(:(?<mod>\w+))?(\[(?<arg>.*?)\])?\}");
+//        private Regex variableSearch = new Regex(@"\{(?<var>\w+)(:(?<mod>\w+))?(\[(?<arg>.*?)\])?\}");
         public DirectoryTemplate? ParentTemplate { get; set; } = null;
         public int? ParentTemplateId { get; set; } = null;
 
@@ -218,9 +219,20 @@ namespace BLAZAM.Database.Models.Templates
         [NotMapped]
         public HashSet<DirectoryTemplate> ChildTemplates { get; set; }
 
-        public string GenerateUsername(NewUserName newUser)
+        [NotMapped]
+        public bool HasIncrementorVariable
         {
-            return ReplaceVariables(EffectiveUsernameFormula, newUser);
+            get
+            {
+
+                return variableSearch.Matches(EffectiveUsernameFormula)
+                    .Any(match => match.Groups["var"].Value == "#");
+            }
+        }
+        public string GenerateUsername(NewUserName newUser, int? incrementedNumber = null)
+        {
+            return ReplaceVariables(EffectiveUsernameFormula, newUser,incrementedNumber:incrementedNumber);
+            
 
         }
         public string ReplaceVariablesOld(string toParse, NewUserName newUser)
@@ -253,20 +265,19 @@ namespace BLAZAM.Database.Models.Templates
             return toParse;
 
         }
-        public string ReplaceVariables(string? toParse, NewUserName? newUser = null, string? username = null)
+        public string ReplaceVariables(string? toParse, NewUserName? newUser = null, string? username = null, int? incrementedNumber = null)
         {
             if (toParse.IsNullOrEmpty())
             {
                 return "";
             }
 
-            var regex = new Regex(@"\{(?<var>\w+)(:(?<mod>\w+))?(\[(?<arg>.*?)\])?\}");
-            if (!regex.IsMatch(toParse))
+            if (!variableSearch.IsMatch(toParse))
             {
                 return toParse;
             }
 
-            return regex.Replace(toParse, match =>
+            return variableSearch.Replace(toParse, match =>
             {
                 var variable = match.Groups["var"].Value.ToLower();
                 var modifier = match.Groups["mod"].Value;
@@ -274,6 +285,11 @@ namespace BLAZAM.Database.Models.Templates
 
                 switch (variable)
                 {
+                    case "#": return incrementedNumber.ToString() ?? "";
+                    case ".": return incrementedNumber != null ? "." : "";
+                    case "_": return incrementedNumber != null ? "_" : "";
+                    case "-": return incrementedNumber != null ? "-" : "";
+                    case " ": return incrementedNumber != null ? " " : "";
                     case "fn": return ProcessVariable(newUser?.GivenName, modifier, arg);
                     case "fi": return ProcessVariable(Substring(newUser?.GivenName, 0, 1), modifier, arg);
                     case "mn": return ProcessVariable(newUser?.MiddleName, modifier, arg);

--- a/BLAZAMDatabase/Models/Templates/DirectoryTemplate.cs
+++ b/BLAZAMDatabase/Models/Templates/DirectoryTemplate.cs
@@ -18,7 +18,7 @@ namespace BLAZAM.Database.Models.Templates
     public class DirectoryTemplate : RecoverableAppDbSetBase
     {
         private Regex variableSearch = new Regex(@"\{(?<var>[\w#\.\- ]+)(:(?<mod>\w+))?(\[(?<arg>.*?)\])?\}");
-//        private Regex variableSearch = new Regex(@"\{(?<var>\w+)(:(?<mod>\w+))?(\[(?<arg>.*?)\])?\}");
+
         public DirectoryTemplate? ParentTemplate { get; set; } = null;
         public int? ParentTemplateId { get; set; } = null;
 

--- a/BLAZAMDatabase/Models/Templates/DirectoryTemplate.cs
+++ b/BLAZAMDatabase/Models/Templates/DirectoryTemplate.cs
@@ -285,7 +285,7 @@ namespace BLAZAM.Database.Models.Templates
 
                 switch (variable)
                 {
-                    case "#": return incrementedNumber.ToString() ?? "";
+                    case "#": return incrementedNumber?.ToString() ?? "";
                     case ".": return incrementedNumber != null ? "." : "";
                     case "_": return incrementedNumber != null ? "_" : "";
                     case "-": return incrementedNumber != null ? "-" : "";

--- a/BLAZAMGui/Helper/TemplateHelpers.cs
+++ b/BLAZAMGui/Helper/TemplateHelpers.cs
@@ -36,6 +36,19 @@ namespace BLAZAM.Gui.Helpers
                 newUser = parentOU.CreateUser(displayName);
 
                 newUser.SAMAccountName = template.GenerateUsername(newUserName);
+                if (template.HasIncrementorVariable)
+                {
+                    var conflictAttempt = 0;
+                    while(directory.Users.FindUserByUsername(newUser.SAMAccountName,exactMatch:true) != null)
+                    {
+                        newUser.SAMAccountName = template.GenerateUsername(newUserName, conflictAttempt + 2);
+                        conflictAttempt++;
+                        if (conflictAttempt > 28)
+                        {
+                            throw new AppException("Could not generate a unique username after multiple attempts. Please adjust the template or try again.");
+                        }
+                    }
+                }
                 newUser.DisplayName = displayName;
                 newUser.StagePasswordChange(template.GeneratePassword(newUserName).ToSecureString());
                 if (template.EffectiveRequirePasswordChange == true)

--- a/BLAZAMGui/UI/Settings/Templates/VariableTable.razor
+++ b/BLAZAMGui/UI/Settings/Templates/VariableTable.razor
@@ -335,6 +335,51 @@
             <td></td>
 
         </tr>
+        <tr>
+            <td>#</td>
+            <td>@AppLocalization["Username Number Incrementor"]</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+
+        </tr>
+        <tr>
+            <td>.</td>
+            <td>@AppLocalization["Username Incrementor Separator"]</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+
+        </tr>
+        <tr>
+            <td> </td>
+            <td>@AppLocalization["Username Incrementor Separator"]</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+
+        </tr>
+        <tr>
+            <td>_</td>
+            <td>@AppLocalization["Username Incrementor Separator"]</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+
+        </tr>
+        <tr>
+            <td>-</td>
+            <td>@AppLocalization["Username Incrementor Separator"]</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+
+        </tr>
     </tbody>
 </MudSimpleTable>
 <MudText Typo="Typo.h6">
@@ -360,6 +405,10 @@
         <tr>
             <td>{fn:l[2]}</td>
             <td>Returns the first two characters of the first name in lower case</td>
+        </tr>
+        <tr>
+            <td>{fi:l}{ln:l}{.}{#}</td>
+            <td>Returns the first initial in lower case, the last name in lower case, and if a username conflicts, a period separator and an incrementing number to resolve the conflict.</td>
         </tr>
 
         <tr>


### PR DESCRIPTION
Added support for incrementor variables ({#}, {.}, { }, {_}, and {-}) in username templates to enable automatic conflict resolution by generating unique usernames. Updated DirectoryTemplate logic to detect and handle incrementor variables, retrying with incremented values if conflicts occur (up to 28 attempts). Enhanced variable parsing regex to support special characters. Updated VariableTable.razor to document and provide examples for these new variables. Bumped project version to 2025.12.27.1514.

closes #1228