### PR TITLE
Add configurable time frames to dashboard widgets

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.4.11</AssemblyVersion>
-		<Version>2025.12.28.1548</Version>
+		<Version>2025.12.28.1836</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.4.11</AssemblyVersion>
-		<Version>2025.12.28.1836</Version>
+		<Version>2025.12.28.1859</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMActiveDirectory/Interfaces/IADUserSearcher.cs
+++ b/BLAZAMActiveDirectory/Interfaces/IADUserSearcher.cs
@@ -17,8 +17,8 @@ namespace BLAZAM.ActiveDirectory.Interfaces
         Task<List<IADUser>> FindNewUsersAsync(int maxAgeInDays = 14, bool ignoreDisabledUsers = true);
         List<IADUser>? FindChangedUsers(bool ignoreDisabledUsers = true, int daysBackToSearch = 90);
         Task<List<IADUser>> FindChangedUsersAsync(bool ignoreDisabledUsers = true);
-        Task<List<IADUser>> FindChangedPasswordUsersAsync(bool ignoreDisabledUsers = true);
-        List<IADUser>? FindChangedPasswordUsers(bool ignoreDisabledUsers = true);
+        Task<List<IADUser>> FindChangedPasswordUsersAsync(int maxAgeInDays = 90, bool ignoreDisabledUsers = true);
+        List<IADUser>? FindChangedPasswordUsers(int maxAgeInDays = 90, bool ignoreDisabledUsers = true);
         List<IADUser> FindExpiredUsers(bool ignoreDisabledUsers = true);
         IADUser? FindUserByDN(string? dn, bool ignoreDisabledUsers = true);
     }

--- a/BLAZAMActiveDirectory/Searchers/ADUserSearcher.cs
+++ b/BLAZAMActiveDirectory/Searchers/ADUserSearcher.cs
@@ -139,17 +139,17 @@ namespace BLAZAM.ActiveDirectory.Searchers
 
         }
 
-        public async Task<List<IADUser>> FindChangedPasswordUsersAsync(bool ignoreDisabledUsers = true)
+        public async Task<List<IADUser>> FindChangedPasswordUsersAsync(int maxAgeInDays = 90, bool ignoreDisabledUsers = true)
         {
             return await Task.Run(() =>
             {
-                return FindChangedPasswordUsers(ignoreDisabledUsers);
+                return FindChangedPasswordUsers(maxAgeInDays, ignoreDisabledUsers);
             });
         }
 
-        public List<IADUser> FindChangedPasswordUsers(bool ignoreDisabledUsers = true)
+        public List<IADUser> FindChangedPasswordUsers(int maxAgeInDays = 90, bool ignoreDisabledUsers = true)
         {
-            var threeMonthsAgo = DateTime.Today - TimeSpan.FromDays(90);
+            var timeframe = DateTime.Today - TimeSpan.FromDays(maxAgeInDays);
 
             var results = new ADSearch(Directory)
             {
@@ -157,7 +157,7 @@ namespace BLAZAM.ActiveDirectory.Searchers
                 EnabledOnly = ignoreDisabledUsers,
                 Fields = new()
                 {
-                    PasswordLastSet = threeMonthsAgo
+                    PasswordLastSet = timeframe
                 }
 
             }.Search<ADUser, IADUser>();

--- a/BLAZAMDatabase/Models/User/UserDashboardWidget.cs
+++ b/BLAZAMDatabase/Models/User/UserDashboardWidget.cs
@@ -25,6 +25,8 @@
         public int Order { get; set; }
         public int ItemsPerPage { get; set; } = 5;
 
+        public string? JsonSettings { get; set; }
+
         public AppUser User { get; set; }
         public int UserId { get; set; }
 

--- a/BLAZAMGui/UI/Dashboard/CurrentUserDashboardWidgets.razor
+++ b/BLAZAMGui/UI/Dashboard/CurrentUserDashboardWidgets.razor
@@ -7,7 +7,7 @@
 {
     @if (CurrentUser.State != null && CurrentUser.State.Preferences != null && allWidgets.Count > 0)
     {
-        if (_editMode)
+        if (EditMode)
         {
             <MudAlert Severity="Severity.Info">
                 @AppHelpLocalization[HelpLang.Rearrange_Dashboard_Help]
@@ -22,8 +22,8 @@
                               ItemsSelector="ItemSelector"
                               ItemDraggingClass="mud-info-text"
                               DisabledClass=""
-                              ItemsClassSelector=@((item,name)=>{return !_editMode ? "cursor-default" : "cursor-move";})
-                              ItemDisabled=@((item)=>{return !_editMode;})
+                              ItemsClassSelector=@((item,name)=>{return !EditMode ? "cursor-default" : "cursor-move";})
+                              ItemDisabled=@((item)=>{return !EditMode;})
                               ItemDropped="ItemDropped"
                               Class="d-flex flex-wrap flex-grow-1 mud-width-full  my-5 cursor-">
                 <ChildContent>
@@ -80,7 +80,7 @@
                                                    OnClick="@(()=>{OnRefreshWidget?.Invoke(widget);})" />
 
 
-                                    <AppCloseButton Disabled="!_editMode"
+                                    <AppCloseButton Disabled="!EditMode"
                                                     Tooltip=@AppLocalization[Lang.Remove]
                                                     OnClick=@(async()=>{await RemoveWidget(context);}) />
 
@@ -89,6 +89,7 @@
 
                                     <DynamicComponent Parameters="@(new Dictionary<string,object>(){
                                                                                   {"ItemsPerPage",context.ItemsPerPage>5?context.ItemsPerPage:5},
+                                                                                  {"JsonSettings",context.JsonSettings},
                                                                                   {"WidgetType",context.WidgetType}
                                                                                   })"
                                   Type="@widget.GetType()" />
@@ -115,7 +116,7 @@
             </MudContainer>
 
         }
-        if (_editMode)
+        if (EditMode)
         {
             <MudAlert Severity="Severity.Info">
                 @AppHelpLocalization[HelpLang.Rearrange_Dashboard_Help]
@@ -126,11 +127,11 @@
                   Style="justify-content: flex-end;"
                   Row=true>
             <AppTooltip Text=@AppLocalization[Lang.Edit]>
-                <MudFab StartIcon="@(!_editMode ? Icons.Material.Filled.Edit : Icons.Material.Filled.EditOff)"
-                        Color="@(!_editMode ? Color.Success : Color.Error)"
-                        OnClick="@(()=>{_editMode = !_editMode; widgetContainer?.Refresh();})" />
+                <MudFab StartIcon="@(!EditMode ? Icons.Material.Filled.Edit : Icons.Material.Filled.EditOff)"
+                        Color="@(!EditMode ? Color.Success : Color.Error)"
+                        OnClick="@(()=>{EditMode = !EditMode; widgetContainer?.Refresh();})" />
             </AppTooltip>
-            @if (_editMode)
+            @if (EditMode)
             {
                 if (allWidgets.Count > CurrentUser.State?.Preferences?.DashboardWidgets.Count)
                 {

--- a/BLAZAMGui/UI/Dashboard/CurrentUserDashboardWidgets.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/CurrentUserDashboardWidgets.razor.cs
@@ -6,7 +6,7 @@ namespace BLAZAM.Gui.UI.Dashboard
 {
     public partial class CurrentUserDashboardWidgets : AppComponentBase
     {
-        private bool _editMode;
+        public bool EditMode { get; protected set; }
 
         private bool _initialized;
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/ChangedEntriesWidget.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/ChangedEntriesWidget.razor
@@ -1,5 +1,9 @@
-﻿@inherits Widget
+﻿@inherits TimeFrameWidget
 @attribute [Authorize]
+<MudTimeFramePicker TimeFrame=@_timeFrame
+                    TimeFrameChanged=SetTimeFrame
+                    Disabled="@(!CurrentUserDashboardWidgets.EditMode)"
+                    Class="mx-3" />
 <MudDataGrid T="IDirectoryEntryAdapter"
              Items="ChangedEntries"
              RowClick="@RowClicked"

--- a/BLAZAMGui/UI/Dashboard/Widgets/ChangedEntriesWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/ChangedEntriesWidget.razor.cs
@@ -2,11 +2,11 @@
 
 namespace BLAZAM.Gui.UI.Dashboard.Widgets
 {
-    public partial class ChangedEntriesWidget : Widget
+    public partial class ChangedEntriesWidget : TimeFrameWidget
     {
         public ChangedEntriesWidget()
         {
-            Title = Localization.AppLocalization.Entries_changed_in_the_last_24_hours;
+            Title = Localization.AppLocalization.Changed_Entries;
             WidgetType = DashboardWidgetType.ChangedEntries;
         }
 
@@ -20,7 +20,7 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         {
             LoadingData = true;
             var search = new ADSearch(Directory);
-            search.Fields.Changed = DateTime.Now.AddDays(-1);
+            search.Fields.Changed = DateTime.UtcNow - _timeFrame;
             ChangedEntries = (await search.SearchAsync<DirectoryEntryAdapter, IDirectoryEntryAdapter>()).Where(x => x.CanRead).ToList();
             LoadingData = false;
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/ChangedPasswordsWidget.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/ChangedPasswordsWidget.razor
@@ -1,6 +1,9 @@
-﻿@inherits Widget
+﻿@inherits TimeFrameWidget
 @attribute [Authorize]
-
+<MudTimeFramePicker TimeFrame=@_timeFrame
+                    TimeFrameChanged=SetTimeFrame
+                    Disabled="@(!CurrentUserDashboardWidgets.EditMode)"
+                    Class="mx-3" />
 <MudDataGrid T="IDirectoryEntryAdapter"
              Items="LockedUsers"
              RowClick="@RowClicked"

--- a/BLAZAMGui/UI/Dashboard/Widgets/ChangedPasswordsWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/ChangedPasswordsWidget.razor.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json.Linq;
+
 namespace BLAZAM.Gui.UI.Dashboard.Widgets
 {
     public partial class ChangedPasswordsWidget : TimeFrameWidget
@@ -18,6 +20,7 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
+            LoadSettings();
             LockedUsers = (await Directory.Users.FindChangedPasswordUsersAsync((int)_timeFrame?.TotalDays,false)).Where(u => u.CanRead).ToList();
             LoadingData = false;
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/ChangedPasswordsWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/ChangedPasswordsWidget.razor.cs
@@ -1,11 +1,15 @@
 namespace BLAZAM.Gui.UI.Dashboard.Widgets
 {
-    public partial class ChangedPasswordsWidget : Widget
+    public partial class ChangedPasswordsWidget : TimeFrameWidget
     {
         public ChangedPasswordsWidget()
         {
-            Title = Localization.AppLocalization.Passwords_changed_in_the_last_90_days;
+            Title = Localization.AppLocalization.Changed_Passwords;
             WidgetType = DashboardWidgetType.PasswordsChanged;
+            if (_timeFrame == null)
+            {
+                _timeFrame = TimeSpan.FromDays(90);
+            }
         }
 
         private List<IADUser> LockedUsers = [];
@@ -14,7 +18,7 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
-            LockedUsers = (await Directory.Users.FindChangedPasswordUsersAsync(false)).Where(u => u.CanRead).ToList();
+            LockedUsers = (await Directory.Users.FindChangedPasswordUsersAsync((int)_timeFrame?.TotalDays,false)).Where(u => u.CanRead).ToList();
             LoadingData = false;
 
         }

--- a/BLAZAMGui/UI/Dashboard/Widgets/DeletedEntriesWidget.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/DeletedEntriesWidget.razor
@@ -1,6 +1,9 @@
-﻿@inherits Widget
+﻿@inherits TimeFrameWidget
 @attribute [Authorize]
-
+<MudTimeFramePicker TimeFrame=@_timeFrame 
+    TimeFrameChanged=SetTimeFrame 
+    Disabled="@(!CurrentUserDashboardWidgets.EditMode)"
+    Class="mx-3"/>
 <MudDataGrid T="IDirectoryEntryAdapter"
              Items="DeletedEntries"
              RowClick="@(()=>{Nav.NavigateTo("/recyclebin");})"

--- a/BLAZAMGui/UI/Dashboard/Widgets/DeletedEntriesWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/DeletedEntriesWidget.razor.cs
@@ -1,11 +1,12 @@
 namespace BLAZAM.Gui.UI.Dashboard.Widgets
 {
-    public partial class DeletedEntriesWidget : Widget
+    public partial class DeletedEntriesWidget : TimeFrameWidget
     {
         public DeletedEntriesWidget()
         {
-            Title = Localization.AppLocalization.Entries_deleted_in_the_last_14_days;
+            Title = Localization.AppLocalization.Deleted_Entries;
             WidgetType = DashboardWidgetType.DeletedEntries;
+           
         }
 
         private List<IDirectoryEntryAdapter> DeletedEntries
@@ -14,16 +15,22 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
             set => CurrentUser.State.Cache.Set(this.GetType(), value);
         }
 
-
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
+            TimeSpan? jsonTimespan = JsonSettings?.FromJson<TimeSpan>();
+            if (jsonTimespan.HasValue)
+            {
+                _timeFrame = jsonTimespan;
+            }
+
             var search = new ADSearch(Directory)
             {
                 SearchRoot = Directory.GetDeleteObjectsEntry(),
                 SearchDeleted = true
             };
-            search.Fields.Changed = DateTime.Now.AddDays(-14);
+            search.Fields.Changed = DateTime.Now - _timeFrame;
+            //search.Fields.Changed = DateTime.Now.AddDays(-14);
             DeletedEntries = await search.SearchAsync<DirectoryEntryAdapter, IDirectoryEntryAdapter>();
             LoadingData = false;
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/DeletedEntriesWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/DeletedEntriesWidget.razor.cs
@@ -1,3 +1,5 @@
+using BLAZAM.Database.Models;
+
 namespace BLAZAM.Gui.UI.Dashboard.Widgets
 {
     public partial class DeletedEntriesWidget : TimeFrameWidget
@@ -18,11 +20,7 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
-            TimeSpan? jsonTimespan = JsonSettings?.FromJson<TimeSpan>();
-            if (jsonTimespan.HasValue)
-            {
-                _timeFrame = jsonTimespan;
-            }
+            LoadSettings();
 
             var search = new ADSearch(Directory)
             {

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewComputersWidget.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewComputersWidget.razor
@@ -1,5 +1,9 @@
-﻿@inherits Widget
+﻿@inherits TimeFrameWidget
 @attribute [Authorize]
+<MudTimeFramePicker TimeFrame=@_timeFrame
+                    TimeFrameChanged=SetTimeFrame
+                    Disabled="@(!CurrentUserDashboardWidgets.EditMode)"
+                    Class="mx-3" />
 <NewEntriesWidgetDataGrid Items="@NewComputers"
                           RowsPerPage="@ItemsPerPage"
                           RowsPerPageChanged="@SetRowsPerPage"

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewComputersWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewComputersWidget.razor.cs
@@ -2,11 +2,11 @@ using MudBlazor;
 
 namespace BLAZAM.Gui.UI.Dashboard.Widgets
 {
-    public partial class NewComputersWidget : Widget
+    public partial class NewComputersWidget : TimeFrameWidget
     {
         public NewComputersWidget()
         {
-            Title = Localization.AppLocalization.Computers_created_in_the_last_14_days;
+            Title = Localization.AppLocalization.New_Computers;
             WidgetType = DashboardWidgetType.NewComputers;
         }
 
@@ -19,7 +19,7 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
-            NewComputers = (await Directory.Computers.FindNewComputersAsync()).Where(u => u.CanRead).ToList();
+            NewComputers = (await Directory.Computers.FindNewComputersAsync((int)_timeFrame?.TotalDays)).Where(u => u.CanRead).ToList();
 
             LoadingData = false;
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewComputersWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewComputersWidget.razor.cs
@@ -19,6 +19,8 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
+            LoadSettings();
+
             NewComputers = (await Directory.Computers.FindNewComputersAsync((int)_timeFrame?.TotalDays)).Where(u => u.CanRead).ToList();
 
             LoadingData = false;

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewContactsWidget.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewContactsWidget.razor
@@ -1,5 +1,9 @@
-﻿@inherits Widget
+﻿@inherits TimeFrameWidget
 @attribute [Authorize]
+<MudTimeFramePicker TimeFrame=@_timeFrame
+                    TimeFrameChanged=SetTimeFrame
+                    Disabled="@(!CurrentUserDashboardWidgets.EditMode)"
+                    Class="mx-3" />
 <NewEntriesWidgetDataGrid Items="@NewContacts"
                           RowsPerPage="@ItemsPerPage"
                           RowsPerPageChanged="@SetRowsPerPage"

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewContactsWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewContactsWidget.razor.cs
@@ -19,6 +19,8 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
+            LoadSettings();
+
             NewContacts = (await Directory.Contacts.FindNewContactsAsync((int)_timeFrame?.TotalDays, false)).Where(u => u.CanRead).OrderByDescending(u => u.Created).ToList();
 
             LoadingData = false;

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewContactsWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewContactsWidget.razor.cs
@@ -2,11 +2,11 @@ using MudBlazor;
 
 namespace BLAZAM.Gui.UI.Dashboard.Widgets
 {
-    public partial class NewContactsWidget : Widget
+    public partial class NewContactsWidget : TimeFrameWidget
     {
         public NewContactsWidget()
         {
-            Title = Localization.AppLocalization.Contacts_created_in_the_last_14_days;
+            Title = Localization.AppLocalization.New_Contacts;
             WidgetType = DashboardWidgetType.NewContacts;
         }
 
@@ -19,7 +19,7 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
-            NewContacts = (await Directory.Contacts.FindNewContactsAsync(14, false)).Where(u => u.CanRead).OrderByDescending(u => u.Created).ToList();
+            NewContacts = (await Directory.Contacts.FindNewContactsAsync((int)_timeFrame?.TotalDays, false)).Where(u => u.CanRead).OrderByDescending(u => u.Created).ToList();
 
             LoadingData = false;
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewGroupsWidget.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewGroupsWidget.razor
@@ -1,5 +1,9 @@
-﻿@inherits Widget
+﻿@inherits TimeFrameWidget
 @attribute [Authorize]
+<MudTimeFramePicker TimeFrame=@_timeFrame
+                    TimeFrameChanged=SetTimeFrame
+                    Disabled="@(!CurrentUserDashboardWidgets.EditMode)"
+                    Class="mx-3" />
 <NewEntriesWidgetDataGrid Items="@NewGroups"
                           RowsPerPage="@ItemsPerPage"
                           RowsPerPageChanged="@SetRowsPerPage"

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewGroupsWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewGroupsWidget.razor.cs
@@ -19,6 +19,8 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
+            LoadSettings();
+
             NewGroups = (await Directory.Groups.FindNewGroupsAsync((int)_timeFrame?.TotalDays)).Where(u => u.CanRead).ToList();
 
             LoadingData = false;

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewGroupsWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewGroupsWidget.razor.cs
@@ -2,11 +2,11 @@ using MudBlazor;
 
 namespace BLAZAM.Gui.UI.Dashboard.Widgets
 {
-    public partial class NewGroupsWidget : Widget
+    public partial class NewGroupsWidget : TimeFrameWidget
     {
         public NewGroupsWidget()
         {
-            Title = Localization.AppLocalization.Groups_created_in_the_last_14_days;
+            Title = Localization.AppLocalization.New_Groups;
             WidgetType = DashboardWidgetType.NewGroups;
         }
 
@@ -19,7 +19,7 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
-            NewGroups = (await Directory.Groups.FindNewGroupsAsync()).Where(u => u.CanRead).ToList();
+            NewGroups = (await Directory.Groups.FindNewGroupsAsync((int)_timeFrame?.TotalDays)).Where(u => u.CanRead).ToList();
 
             LoadingData = false;
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewOUsWidget.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewOUsWidget.razor
@@ -1,5 +1,9 @@
-﻿@inherits Widget
+﻿@inherits TimeFrameWidget
 @attribute [Authorize]
+<MudTimeFramePicker TimeFrame=@_timeFrame
+                    TimeFrameChanged=SetTimeFrame
+                    Disabled="@(!CurrentUserDashboardWidgets.EditMode)"
+                    Class="mx-3" />
 <NewEntriesWidgetDataGrid Items="@NewOUs"
                           RowsPerPage="@ItemsPerPage"
                           RowsPerPageChanged="@SetRowsPerPage"

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewOUsWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewOUsWidget.razor.cs
@@ -20,6 +20,8 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
+            LoadSettings();
+
             NewOUs = (await Directory.OUs.FindNewOUsAsync((int)_timeFrame?.TotalDays)).Where(u => u.CanRead).ToList();
 
             LoadingData = false;

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewOUsWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewOUsWidget.razor.cs
@@ -2,11 +2,11 @@ using MudBlazor;
 
 namespace BLAZAM.Gui.UI.Dashboard.Widgets
 {
-    public partial class NewOUsWidget : Widget
+    public partial class NewOUsWidget : TimeFrameWidget
     {
         public NewOUsWidget()
         {
-            Title = Localization.AppLocalization.OUs_created_in_the_last_14_days;
+            Title = Localization.AppLocalization.New_OUs;
             WidgetType = DashboardWidgetType.NewOus;
         }
 
@@ -20,7 +20,7 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
-            NewOUs = (await Directory.OUs.FindNewOUsAsync()).Where(u => u.CanRead).ToList();
+            NewOUs = (await Directory.OUs.FindNewOUsAsync((int)_timeFrame?.TotalDays)).Where(u => u.CanRead).ToList();
 
             LoadingData = false;
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewPrintersWidget.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewPrintersWidget.razor
@@ -1,5 +1,9 @@
-﻿@inherits Widget
+﻿@inherits TimeFrameWidget
 @attribute [Authorize]
+<MudTimeFramePicker TimeFrame=@_timeFrame
+                    TimeFrameChanged=SetTimeFrame
+                    Disabled="@(!CurrentUserDashboardWidgets.EditMode)"
+                    Class="mx-3" />
 <NewEntriesWidgetDataGrid Items="@NewPrinters"
                           RowClick=@GoTo
                           RowsPerPage="@ItemsPerPage"

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewPrintersWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewPrintersWidget.razor.cs
@@ -20,6 +20,8 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
+            LoadSettings();
+
             NewPrinters = (await Directory.Printers.FindNewPrintersAsync((int)_timeFrame?.TotalDays, false)).Where(u => u.CanRead).ToList();
 
             LoadingData = false;

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewPrintersWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewPrintersWidget.razor.cs
@@ -2,11 +2,11 @@ using MudBlazor;
 
 namespace BLAZAM.Gui.UI.Dashboard.Widgets
 {
-    public partial class NewPrintersWidget : Widget
+    public partial class NewPrintersWidget : TimeFrameWidget
     {
         public NewPrintersWidget()
         {
-            Title = Localization.AppLocalization.Printers_created_in_the_last_14_days;
+            Title = Localization.AppLocalization.New_Printers;
             WidgetType = DashboardWidgetType.NewPrinters;
         }
 
@@ -20,7 +20,7 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
-            NewPrinters = (await Directory.Printers.FindNewPrintersAsync(14, false)).Where(u => u.CanRead).ToList();
+            NewPrinters = (await Directory.Printers.FindNewPrintersAsync((int)_timeFrame?.TotalDays, false)).Where(u => u.CanRead).ToList();
 
             LoadingData = false;
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewUsersWidget.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewUsersWidget.razor
@@ -1,5 +1,9 @@
-﻿@inherits Widget
+﻿@inherits TimeFrameWidget
 @attribute [Authorize]
+<MudTimeFramePicker TimeFrame=@_timeFrame
+                    TimeFrameChanged=SetTimeFrame
+                    Disabled="@(!CurrentUserDashboardWidgets.EditMode)"
+                    Class="mx-3" />
 <NewEntriesWidgetDataGrid Items="@NewUsers"
                           RowsPerPage="@ItemsPerPage"
                           RowsPerPageChanged="@SetRowsPerPage"

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewUsersWidget.razor.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewUsersWidget.razor.cs
@@ -2,11 +2,11 @@ using MudBlazor;
 
 namespace BLAZAM.Gui.UI.Dashboard.Widgets
 {
-    public partial class NewUsersWidget : Widget
+    public partial class NewUsersWidget : TimeFrameWidget
     {
         public NewUsersWidget()
         {
-            Title = Localization.AppLocalization.Users_created_in_the_last_14_days;
+            Title = Localization.AppLocalization.New_Users;
             WidgetType = DashboardWidgetType.NewUsers;
         }
 
@@ -19,7 +19,7 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         protected override async Task RefreshDataAsync()
         {
             LoadingData = true;
-            NewUsers = (await Directory.Users.FindNewUsersAsync(14, false)).Where(u => u.CanRead).OrderByDescending(u => u.Created).ToList();
+            NewUsers = (await Directory.Users.FindNewUsersAsync((int)_timeFrame?.TotalDays, false)).Where(u => u.CanRead).OrderByDescending(u => u.Created).ToList();
 
             LoadingData = false;
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/TimeFrameWidget.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/TimeFrameWidget.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BLAZAM.Gui.UI.Dashboard.Widgets
+{
+    public abstract class TimeFrameWidget:Widget
+    {
+        protected TimeSpan? _timeFrame = TimeSpan.FromDays(14);
+
+        protected async Task SetTimeFrame(TimeSpan? timeFrame)
+        {
+            _timeFrame = timeFrame;
+            await SetWidgetJson(timeFrame);
+            
+        }
+
+
+    }
+}

--- a/BLAZAMGui/UI/Dashboard/Widgets/TimeFrameWidget.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/TimeFrameWidget.cs
@@ -10,13 +10,24 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
     {
         protected TimeSpan? _timeFrame = TimeSpan.FromDays(14);
 
+        public TimeFrameWidget():base()
+        {
+            LoadSettings();
+        }
         protected async Task SetTimeFrame(TimeSpan? timeFrame)
         {
             _timeFrame = timeFrame;
             await SetWidgetJson(timeFrame);
             
         }
-
+        protected void LoadSettings()
+        {
+            TimeSpan? jsonTimespan = JsonSettings?.FromJson<TimeSpan>();
+            if (jsonTimespan.HasValue)
+            {
+                _timeFrame = jsonTimespan;
+            }
+        }
 
     }
 }

--- a/BLAZAMGui/UI/Dashboard/Widgets/Widget.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/Widget.cs
@@ -14,6 +14,8 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         public DashboardWidgetType WidgetType { get; set; }
         [Parameter]
         public int ItemsPerPage { get; set; } = 5;
+        [Parameter]
+        public string? JsonSettings { get; set; }   
         [CascadingParameter]
         public CurrentUserDashboardWidgets CurrentUserDashboardWidgets { get; set; }
 
@@ -62,6 +64,19 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
             try
             {
                 CurrentUser.State.Preferences.DashboardWidgets.First(w => w.WidgetType.Equals(WidgetType)).ItemsPerPage = rowPerPage;
+                await CurrentUser.State.SaveDashboardWidgets();
+            }
+            catch (Exception ex)
+            {
+                Loggers.SystemLogger.Error("Error attempting to set a widgets rows per page preference. {Error}", ex);
+            }
+        }
+
+        protected async Task SetWidgetJson(object? obj)
+        {
+            try
+            {
+                CurrentUser.State.Preferences.DashboardWidgets.First(w => w.WidgetType.Equals(WidgetType)).JsonSettings = obj.ToJson();
                 await CurrentUser.State.SaveDashboardWidgets();
             }
             catch (Exception ex)

--- a/BLAZAMGui/UI/Inputs/MudTimeFramePicker.razor
+++ b/BLAZAMGui/UI/Inputs/MudTimeFramePicker.razor
@@ -1,11 +1,15 @@
 ﻿@using BLAZAM.Global.Data
-<MudStack Row=true>
+<MudStack Row=true Class="@Class">
+    <MudSpacer/>
     <MudNumericField T="int"
+        Style="max-width:100px;"
+                    Disabled=@Disabled
                      @bind-Value="count" />
     <MudSelectList T="TimeUnit"
+                   Disabled=@Disabled
                    @bind-Value=selectedTimeUnit
                    Values="_timeUnits" />
-
+    <MudSpacer />
 </MudStack>
 @code {
     private TimeSpan? _timeFrame;
@@ -98,6 +102,16 @@
                 break;
         }
     }
+
+
+    [Parameter]
+    public bool Disabled{ get; set;}
+
+
+    [Parameter]
+    public string? Class{ get; set;}
+
+
     [Parameter]
     public TimeSpan? TimeFrame
     {

--- a/BLAZAMGui/UI/Modals/AppNewsItemDialog.razor
+++ b/BLAZAMGui/UI/Modals/AppNewsItemDialog.razor
@@ -48,7 +48,8 @@
         }
         else
         {
-            CurrentUser.State.ReadNewsItems.Add(new ReadNewsItem { NewsItemId = Item.Id, NewsItemUpdatedAt = Item.UpdatedAt, User = CurrentUser.State.Preferences });
+            var readNewsItem = new ReadNewsItem { NewsItemId = Item.Id, NewsItemUpdatedAt = Item.UpdatedAt, User = CurrentUser.State.Preferences };
+            CurrentUser.State.ReadNewsItems.Add(readNewsItem);
 
         }
         MudDialog.Close(DialogResult.Ok(true));

--- a/BLAZAMLocalization/AppLocalization.Designer.cs
+++ b/BLAZAMLocalization/AppLocalization.Designer.cs
@@ -691,6 +691,24 @@ namespace BLAZAM.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Changed Entries.
+        /// </summary>
+        public static string Changed_Entries {
+            get {
+                return ResourceManager.GetString("Changed_Entries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Changed Passwords.
+        /// </summary>
+        public static string Changed_Passwords {
+            get {
+                return ResourceManager.GetString("Changed_Passwords", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Changes have been saved.
         /// </summary>
         public static string Changes_have_been_saved {
@@ -781,15 +799,6 @@ namespace BLAZAM.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Computers created in the last 14 days.
-        /// </summary>
-        public static string Computers_created_in_the_last_14_days {
-            get {
-                return ResourceManager.GetString("Computers_created_in_the_last_14_days", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Configure.
         /// </summary>
         public static string Configure {
@@ -831,15 +840,6 @@ namespace BLAZAM.Localization {
         public static string Contact_Info {
             get {
                 return ResourceManager.GetString("Contact Info", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Contacts created in the last 14 days.
-        /// </summary>
-        public static string Contacts_created_in_the_last_14_days {
-            get {
-                return ResourceManager.GetString("Contacts_created_in_the_last_14_days", resourceCulture);
             }
         }
         
@@ -1083,6 +1083,15 @@ namespace BLAZAM.Localization {
         public static string Deleted {
             get {
                 return ResourceManager.GetString("Deleted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deleted Entries.
+        /// </summary>
+        public static string Deleted_Entries {
+            get {
+                return ResourceManager.GetString("Deleted_Entries", resourceCulture);
             }
         }
         
@@ -1402,24 +1411,6 @@ namespace BLAZAM.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Entries changed in the last 24 hours.
-        /// </summary>
-        public static string Entries_changed_in_the_last_24_hours {
-            get {
-                return ResourceManager.GetString("Entries_changed_in_the_last_24_hours", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Entries deleted in the last 14 days.
-        /// </summary>
-        public static string Entries_deleted_in_the_last_14_days {
-            get {
-                return ResourceManager.GetString("Entries_deleted_in_the_last_14_days", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Error Message.
         /// </summary>
         public static string Error_Message {
@@ -1659,15 +1650,6 @@ namespace BLAZAM.Localization {
         public static string Groups {
             get {
                 return ResourceManager.GetString("Groups", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Groups created in the last 14 days.
-        /// </summary>
-        public static string Groups_created_in_the_last_14_days {
-            get {
-                return ResourceManager.GetString("Groups_created_in_the_last_14_days", resourceCulture);
             }
         }
         
@@ -2149,6 +2131,42 @@ namespace BLAZAM.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to New Computers.
+        /// </summary>
+        public static string New_Computers {
+            get {
+                return ResourceManager.GetString("New_Computers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New Contacts.
+        /// </summary>
+        public static string New_Contacts {
+            get {
+                return ResourceManager.GetString("New_Contacts", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New Groups.
+        /// </summary>
+        public static string New_Groups {
+            get {
+                return ResourceManager.GetString("New_Groups", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New OU&apos;s.
+        /// </summary>
+        public static string New_OUs {
+            get {
+                return ResourceManager.GetString("New_OUs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to New Password.
         /// </summary>
         public static string New_Password {
@@ -2158,11 +2176,29 @@ namespace BLAZAM.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to New Printers.
+        /// </summary>
+        public static string New_Printers {
+            get {
+                return ResourceManager.GetString("New_Printers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to New template.
         /// </summary>
         public static string New_Template {
             get {
                 return ResourceManager.GetString("New Template", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to New Users.
+        /// </summary>
+        public static string New_Users {
+            get {
+                return ResourceManager.GetString("New_Users", resourceCulture);
             }
         }
         
@@ -2338,15 +2374,6 @@ namespace BLAZAM.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to OU&apos;s created in the last 14 days.
-        /// </summary>
-        public static string OUs_created_in_the_last_14_days {
-            get {
-                return ResourceManager.GetString("OUs_created_in_the_last_14_days", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Parent Template.
         /// </summary>
         public static string Parent_Template {
@@ -2379,15 +2406,6 @@ namespace BLAZAM.Localization {
         public static string PasswordChange {
             get {
                 return ResourceManager.GetString("PasswordChange", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Passwords changed in the last 90 days.
-        /// </summary>
-        public static string Passwords_changed_in_the_last_90_days {
-            get {
-                return ResourceManager.GetString("Passwords_changed_in_the_last_90_days", resourceCulture);
             }
         }
         
@@ -2478,15 +2496,6 @@ namespace BLAZAM.Localization {
         public static string Printers {
             get {
                 return ResourceManager.GetString("Printers", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Printers created in the last 14 days.
-        /// </summary>
-        public static string Printers_created_in_the_last_14_days {
-            get {
-                return ResourceManager.GetString("Printers_created_in_the_last_14_days", resourceCulture);
             }
         }
         
@@ -3594,15 +3603,6 @@ namespace BLAZAM.Localization {
         public static string Users {
             get {
                 return ResourceManager.GetString("Users", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Users created in the last 14 days.
-        /// </summary>
-        public static string Users_created_in_the_last_14_days {
-            get {
-                return ResourceManager.GetString("Users_created_in_the_last_14_days", resourceCulture);
             }
         }
         

--- a/BLAZAMLocalization/AppLocalization.resx
+++ b/BLAZAMLocalization/AppLocalization.resx
@@ -1281,32 +1281,32 @@
   <data name="Disabled_users_changed_in_the_last_90_days" xml:space="preserve">
     <value>Disabled users changed in the last 90 days</value>
   </data>
-  <data name="Entries_changed_in_the_last_24_hours" xml:space="preserve">
-    <value>Entries changed in the last 24 hours</value>
+  <data name="Changed_Entries" xml:space="preserve">
+    <value>Changed Entries</value>
   </data>
-  <data name="Passwords_changed_in_the_last_90_days" xml:space="preserve">
-    <value>Passwords changed in the last 90 days</value>
+  <data name="Changed_Passwords" xml:space="preserve">
+    <value>Changed Passwords</value>
   </data>
-  <data name="Entries_deleted_in_the_last_14_days" xml:space="preserve">
-    <value>Entries deleted in the last 14 days</value>
+  <data name="Deleted_Entries" xml:space="preserve">
+    <value>Deleted Entries</value>
   </data>
-  <data name="Computers_created_in_the_last_14_days" xml:space="preserve">
-    <value>Computers created in the last 14 days</value>
+  <data name="New_Computers" xml:space="preserve">
+    <value>New Computers</value>
   </data>
-  <data name="Contacts_created_in_the_last_14_days" xml:space="preserve">
-    <value>Contacts created in the last 14 days</value>
+  <data name="New_Contacts" xml:space="preserve">
+    <value>New Contacts</value>
   </data>
-  <data name="Groups_created_in_the_last_14_days" xml:space="preserve">
-    <value>Groups created in the last 14 days</value>
+  <data name="New_Groups" xml:space="preserve">
+    <value>New Groups</value>
   </data>
-  <data name="OUs_created_in_the_last_14_days" xml:space="preserve">
-    <value>OU's created in the last 14 days</value>
+  <data name="New_OUs" xml:space="preserve">
+    <value>New OU's</value>
   </data>
-  <data name="Printers_created_in_the_last_14_days" xml:space="preserve">
-    <value>Printers created in the last 14 days</value>
+  <data name="New_Printers" xml:space="preserve">
+    <value>New Printers</value>
   </data>
-  <data name="Users_created_in_the_last_14_days" xml:space="preserve">
-    <value>Users created in the last 14 days</value>
+  <data name="New_Users" xml:space="preserve">
+    <value>New Users</value>
   </data>
   <data name="Text" xml:space="preserve">
     <value>Text</value>

--- a/BLAZAMLocalization/Lang.cs
+++ b/BLAZAMLocalization/Lang.cs
@@ -591,14 +591,14 @@
         public static readonly string Reboot_Shutdown_Success = "Reboot_Shutdown_Success";
         public static readonly string Reboot_Shutdown_Failure = "Reboot_Shutdown_Failure";
         public static readonly string Disabled_users_changed_in_the_last_90_days = "Disabled users changed in the last 90 days";
-        public static readonly string Entries_changed_in_the_last_24_hours = "Entries changed in the last 24 hours";
-        public static readonly string Passwords_changed_in_the_last_90_days = "Passwords changed in the last 90 days";
-        public static readonly string Entries_deleted_in_the_last_14_days = "Entries deleted in the last 14 days";
-        public static readonly string Computers_created_in_the_last_14_days = "Computers created in the last 14 days";
-        public static readonly string Contacts_created_in_the_last_14_days = "Contacts created in the last 14 days";
-        public static readonly string Groups_created_in_the_last_14_days = "Groups created in the last 14 days";
-        public static readonly string OUs_created_in_the_last_14_days = "OU\'s created in the last 14 days";
-        public static readonly string Printers_created_in_the_last_14_days = "Printers created in the last 14 days";
-        public static readonly string Users_created_in_the_last_14_days = "Users created in the last 14 days";
+        public static readonly string Changed_Entries = "Entries changed in the last 24 hours";
+        public static readonly string Changed_Passwords = "Passwords changed in the last 90 days";
+        public static readonly string Deleted_Entries = "Deleted_Entries";
+        public static readonly string New_Computers = "Computers created in the last 14 days";
+        public static readonly string New_Contacts = "Contacts created in the last 14 days";
+        public static readonly string New_Groups = "Groups created in the last 14 days";
+        public static readonly string New_OUs = "OU\'s created in the last 14 days";
+        public static readonly string New_Printers = "Printers created in the last 14 days";
+        public static readonly string New_Users = "Users created in the last 14 days";
     }
 }

--- a/BLAZAMSession/ApplicationUserState.cs
+++ b/BLAZAMSession/ApplicationUserState.cs
@@ -332,6 +332,7 @@ namespace BLAZAM.Session
                         dbWidget.Slot = prefWidget.Slot;
                         dbWidget.Order = prefWidget.Order;
                         dbWidget.ItemsPerPage = prefWidget.ItemsPerPage;
+                        dbWidget.JsonSettings = prefWidget.JsonSettings;
                     }
                     else
                     {


### PR DESCRIPTION
Introduce a reusable TimeFrameWidget base class for dashboard widgets, enabling user-selectable time frames via a new MudTimeFramePicker component. Refactor all relevant widgets to inherit from TimeFrameWidget and use the selected time frame in their data queries. Persist widget-specific settings (like time frame) per user using a new JsonSettings property. Update localization keys for widget titles to be more generic. Refactor dashboard edit mode logic and make FindChangedPasswordUsers methods accept a configurable time frame. Includes minor bug fixes and improvements.