### PR TITLE
Improve password reset email formatting and info

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.0</AssemblyVersion>
-		<Version>2026.01.02.1931</Version>
+		<Version>2026.01.03.0043</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMEmailMessage/Email/Messages/PasswordResetEmailMessage.razor
+++ b/BLAZAMEmailMessage/Email/Messages/PasswordResetEmailMessage.razor
@@ -14,14 +14,7 @@
 
 
         </MudText>
-        @if (!IpAddress.IsNullOrEmpty())
-        {
-        <MudText Align="Align.Center">Requested from: @IpAddress</MudText>
-        }
-        @if (!Browser.IsNullOrEmpty())
-        {
-            <MudText Align="Align.Center">Requested on: @Browser</MudText>
-        }
+
         <MudText Align="Align.Center"> <EmailLink Href="@ResetUri">Click here to reset your password</EmailLink></MudText>
 
     }
@@ -34,8 +27,15 @@
 
     }
     <MudDivider Class="my-6" />
-    <MudText Align="Align.Center">If you did not request this reset, you can safely ignore it.</MudText>@* 
-    <MudText Align="Align.Center">If the link above does not work copy the following into the address bar. @ResetUri</MudText> *@
+    <MudText Align="Align.Center">If you did not request this reset, you can safely ignore it.</MudText> <br />
+    @if (!IpAddress.IsNullOrEmpty() || !Browser.IsNullOrEmpty())
+    {
+        <MudText Align="Align.Center">This request originated from : @IpAddress<br /> @Browser</MudText>
+    
+        <br />
+    }
+
+    <MudText Align="Align.Center">If the link above does not work copy the following into the address bar.<br /> @(DatabaseCache.ApplicationSettings.ForceHTTPS ? "https://" : "http://" + DatabaseCache.ApplicationSettings.AppFQDN + ResetUri)</MudText>
 </EmailTemplateBody>
 
 
@@ -54,6 +54,8 @@
             .UseLayout<DefaultEmailLayout>()
             .AddServiceProvider(ApplicationInfo.services)
             .Set(c => c.ResetUri, ResetUri)
+            .Set(c => c.IpAddress, IpAddress)
+            .Set(c => c.Browser, Browser)
             .Set(c => c.Expires, Expires).Render();
 }
 


### PR DESCRIPTION
Refactored PasswordResetEmailMessage to always show a clickable reset link and provide clearer instructions if the link does not work. IP address and browser details are now shown together if present, with improved formatting. Updated the Render method to set these parameters explicitly. Bumped project version to 2026.01.03.0043.