### PR TITLE
Fix possible UI blocking of Rules

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.1</AssemblyVersion>
-		<Version>2026.02.06.1656</Version>
+		<Version>2026.02.14.1556</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMGui/UI/Settings/Rules/RulePreview.razor
+++ b/BLAZAMGui/UI/Settings/Rules/RulePreview.razor
@@ -266,20 +266,27 @@
 
 
            LoadingData = true;
-           using var context = await DbFactory.CreateDbContextAsync();
-           _settings = await context.GlobalAutomationRuleSettings.FirstOrDefaultAsync();
-           Rule = await context.AutomationRules.FirstAsync(r => r.Id == Rule.Id);
-           filteredEntries = await RulesProcessor.GetFilteredEntries(Rule);
-           var auditTimestampCutoff = DateTime.UtcNow.Subtract(TimeSpan.FromDays(30));
-           _auditErrors = await Context.AutomationRuleAuditLog
-               .Where(x => x.Level == LogEventLevel.Error && x.AutomationRuleId == Rule.Id && x.Timestamp>auditTimestampCutoff)
-               .OrderByDescending(x => x.Timestamp)
-               .ToListAsync();
-           _recentAudits = await Context.AutomationRuleAuditLog
-               .Where(x => x.AutomationRuleId == Rule.Id && x.Timestamp > auditTimestampCutoff)
-               .OrderByDescending(x => x.Timestamp)
-               .Take(100)
-               .ToListAsync();
+           try
+           {
+               using var context = await DbFactory.CreateDbContextAsync();
+               _settings = await context.GlobalAutomationRuleSettings.FirstOrDefaultAsync();
+               Rule = await context.AutomationRules.FirstAsync(r => r.Id == Rule.Id);
+               var auditTimestampCutoff = DateTime.UtcNow.Subtract(TimeSpan.FromDays(30));
+               _auditErrors = await Context.AutomationRuleAuditLog
+                   .Where(x => x.Level == LogEventLevel.Error && x.AutomationRuleId == Rule.Id && x.Timestamp > auditTimestampCutoff)
+                   .OrderByDescending(x => x.Timestamp)
+                   .ToListAsync();
+               _recentAudits = await Context.AutomationRuleAuditLog
+                   .Where(x => x.AutomationRuleId == Rule.Id && x.Timestamp > auditTimestampCutoff)
+                   .OrderByDescending(x => x.Timestamp)
+                   .Take(100)
+                   .ToListAsync();
+           }
+           catch(Exception ex)
+           {
+               SnackBarService.Warning(AppHelpLocalization[(HelpLang.Unexpected_Error_Occurred)]);
+               Loggers.SystemLogger.Error(ex, "Error loading rule preview");
+           }
            LoadingData = false;
            LoadFilteredEntries();
 


### PR DESCRIPTION
Wrapped rule preview data loading logic in a try-catch block to handle exceptions gracefully. Now, if an error occurs while loading settings, rules, or audit logs, a warning is shown to the user and the error is logged, improving user feedback and reliability.