### PR TITLE
Convert to NuGet Central Package Management (CPM)

### DIFF
--- a/BLAZAM.Tests/BLAZAM.Tests.csproj
+++ b/BLAZAM.Tests/BLAZAM.Tests.csproj
@@ -15,44 +15,44 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
+		<PackageReference Include="coverlet.collector">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.msbuild" Version="6.0.4">
+		<PackageReference Include="coverlet.msbuild">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.22">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MudBlazor" Version="8.13.0" />
-		<PackageReference Include="Octokit" Version="14.0.0" />
-		<PackageReference Include="PreMailer.Net" Version="2.7.2" />
-		<PackageReference Include="Serilog" Version="4.3.0" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.6" />
-		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.11" />
-		<PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.11" />
-		<PackageReference Include="System.Drawing.Common" Version="9.0.11" />
-		<PackageReference Include="System.Management" Version="9.0.11" />
-		<PackageReference Include="System.Security.Permissions" Version="9.0.11" />
-		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+		<PackageReference Include="Microsoft.Extensions.Http" />
+		<PackageReference Include="Microsoft.Extensions.Localization" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="MudBlazor" />
+		<PackageReference Include="Octokit" />
+		<PackageReference Include="PreMailer.Net" />
+		<PackageReference Include="Serilog" />
+		<PackageReference Include="Serilog.Extensions.Logging" />
+		<PackageReference Include="SixLabors.ImageSharp" />
+		<PackageReference Include="Swashbuckle.AspNetCore" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
+		<PackageReference Include="System.Diagnostics.PerformanceCounter" />
+		<PackageReference Include="System.DirectoryServices.Protocols" />
+		<PackageReference Include="System.Drawing.Common" />
+		<PackageReference Include="System.Management" />
+		<PackageReference Include="System.Security.Permissions" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.1</AssemblyVersion>
-		<Version>2026.02.14.1715</Version>
+		<Version>2026.02.16.0354</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
@@ -46,50 +46,50 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BlazorTemplater" Version="1.5.1" />
-		<PackageReference Include="Cassia" Version="2.0.0.60" />
-		<PackageReference Include="DuoUniversal" Version="1.3.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.22" />
-		<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-		<PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="2.3.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.22">
+		<PackageReference Include="BlazorTemplater" />
+		<PackageReference Include="Cassia" />
+		<PackageReference Include="DuoUniversal" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+		<PackageReference Include="Microsoft.AspNetCore.Components" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+		<PackageReference Include="Microsoft.AspNetCore.ResponseCompression" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-		<PackageReference Include="MudBlazor" Version="8.13.0" />
-		<PackageReference Include="MudBlazor.ThemeManager" Version="3.0.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-		<PackageReference Include="Octokit" Version="14.0.0" />
-		<PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-		<PackageReference Include="PreMailer.Net" Version="2.7.2" />
-		<PackageReference Include="Serilog" Version="4.3.0" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
-		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.6" />
-		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.11" />
-		<PackageReference Include="System.DirectoryServices" Version="9.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+		<PackageReference Include="Microsoft.Extensions.Http" />
+		<PackageReference Include="Microsoft.Extensions.Http.Polly" />
+		<PackageReference Include="Microsoft.Extensions.Localization" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="MudBlazor" />
+		<PackageReference Include="MudBlazor.ThemeManager" />
+		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="Octokit" />
+		<PackageReference Include="Polly.Contrib.WaitAndRetry" />
+		<PackageReference Include="PreMailer.Net" />
+		<PackageReference Include="Serilog" />
+		<PackageReference Include="Serilog.Extensions.Logging" />
+		<PackageReference Include="Swashbuckle.AspNetCore" />
+		<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
+		<PackageReference Include="System.Diagnostics.PerformanceCounter" />
+		<PackageReference Include="System.DirectoryServices" />
 
-		<PackageReference Include="System.DirectoryServices.AccountManagement" Version="9.0.11" />
+		<PackageReference Include="System.DirectoryServices.AccountManagement" />
 
-		<PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.11" />
+		<PackageReference Include="System.DirectoryServices.Protocols" />
 
-		<PackageReference Include="System.Drawing.Common" Version="9.0.11" />
+		<PackageReference Include="System.Drawing.Common" />
 
-		<PackageReference Include="System.Management" Version="9.0.11" />
+		<PackageReference Include="System.Management" />
 
-		<PackageReference Include="System.Security.Permissions" Version="9.0.11" />
+		<PackageReference Include="System.Security.Permissions" />
 
-		<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Common" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/BLAZAMActiveDirectory/BLAZAMActiveDirectory.csproj
+++ b/BLAZAMActiveDirectory/BLAZAMActiveDirectory.csproj
@@ -8,29 +8,29 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.22">
+    <PackageReference Include="Microsoft.AspNetCore.Components" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-    <PackageReference Include="MudBlazor" Version="8.13.0" />
-    <PackageReference Include="PreMailer.Net" Version="2.7.2" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.11" />
-    <PackageReference Include="System.Management" Version="9.0.11" />
-    <PackageReference Include="System.Security.Permissions" Version="9.0.11" />
-	<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-	<PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.10" />
-    <PackageReference Include="System.Diagnostics.EventLog" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Localization" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="MudBlazor" />
+    <PackageReference Include="PreMailer.Net" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="System.DirectoryServices.Protocols" />
+    <PackageReference Include="System.Management" />
+    <PackageReference Include="System.Security.Permissions" />
+	<PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+	<PackageReference Include="Microsoft.CodeAnalysis.Common" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" />
+    <PackageReference Include="System.Diagnostics.EventLog" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BLAZAMCommon.Tests/BLAZAMCommon.Tests.csproj
+++ b/BLAZAMCommon.Tests/BLAZAMCommon.Tests.csproj
@@ -9,37 +9,37 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector" Version="6.0.4">
+		<PackageReference Include="coverlet.collector">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.msbuild" Version="6.0.4">
+		<PackageReference Include="coverlet.msbuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.22" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.22" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.22" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.22">
+		<PackageReference Include="Microsoft.AspNetCore.Components" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
-		<PackageReference Include="Serilog" Version="4.3.0" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-		<PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.11" />
-		<PackageReference Include="System.Management" Version="9.0.11" />
-		<PackageReference Include="System.Security.Permissions" Version="9.0.11" />
-		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
+		<PackageReference Include="Pomelo.EntityFrameworkCore.MySql" />
+		<PackageReference Include="Serilog" />
+		<PackageReference Include="Serilog.Extensions.Logging" />
+		<PackageReference Include="SixLabors.ImageSharp" />
+		<PackageReference Include="System.DirectoryServices.Protocols" />
+		<PackageReference Include="System.Management" />
+		<PackageReference Include="System.Security.Permissions" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/BLAZAMCommon/BLAZAMCommon.csproj
+++ b/BLAZAMCommon/BLAZAMCommon.csproj
@@ -18,38 +18,38 @@
   </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="BlazorTemplater" Version="1.5.1" />
-	  <PackageReference Include="Cassia" Version="2.0.0.60" />
-	  <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.22">
+	  <PackageReference Include="BlazorTemplater" />
+	  <PackageReference Include="Cassia" />
+	  <PackageReference Include="Microsoft.AspNetCore.Components" />
+	  <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.22">
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-	  <PackageReference Include="MudBlazor" Version="8.13.0" />
-	  <PackageReference Include="MudBlazor.Markdown" Version="8.11.0" />
-	  <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-	  <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
-	  <PackageReference Include="Serilog" Version="4.3.0" />
-	  <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-	  <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-	  <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-	  <PackageReference Include="System.DirectoryServices" Version="9.0.11" />
-	  <PackageReference Include="System.DirectoryServices.AccountManagement" Version="9.0.11" />
-	  <PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.11" />
-	  <PackageReference Include="System.Management" Version="9.0.11" />
-	  <PackageReference Include="System.Security.Permissions" Version="9.0.11" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+	  <PackageReference Include="MudBlazor" />
+	  <PackageReference Include="MudBlazor.Markdown" />
+	  <PackageReference Include="Newtonsoft.Json" />
+	  <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" />
+	  <PackageReference Include="Serilog" />
+	  <PackageReference Include="Serilog.AspNetCore" />
+	  <PackageReference Include="Serilog.Extensions.Logging" />
+	  <PackageReference Include="SixLabors.ImageSharp" />
+	  <PackageReference Include="System.DirectoryServices" />
+	  <PackageReference Include="System.DirectoryServices.AccountManagement" />
+	  <PackageReference Include="System.DirectoryServices.Protocols" />
+	  <PackageReference Include="System.Management" />
+	  <PackageReference Include="System.Security.Permissions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BLAZAMDatabase.Tests/BLAZAMDatabase.Tests.csproj
+++ b/BLAZAMDatabase.Tests/BLAZAMDatabase.Tests.csproj
@@ -11,18 +11,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.AspNetCore.Components" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/BLAZAMDatabase/BLAZAMDatabase.csproj
+++ b/BLAZAMDatabase/BLAZAMDatabase.csproj
@@ -8,33 +8,33 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.22">
+	  <PackageReference Include="Microsoft.AspNetCore.Components" />
+	  <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.22">
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-	  <PackageReference Include="MudBlazor" Version="8.13.0" />
-	  <PackageReference Include="MudBlazor.Markdown" Version="8.11.0" />
-	  <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
-	  <PackageReference Include="Serilog" Version="4.3.0" />
-	  <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-	  <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-	  <PackageReference Include="System.Data.SQLite" Version="2.0.2" />
-	  <PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.11" />
-	  <PackageReference Include="System.Management" Version="9.0.11" />
-	  <PackageReference Include="System.Security.Permissions" Version="9.0.11" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+	  <PackageReference Include="MudBlazor" />
+	  <PackageReference Include="MudBlazor.Markdown" />
+	  <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" />
+	  <PackageReference Include="Serilog" />
+	  <PackageReference Include="Serilog.Extensions.Logging" />
+	  <PackageReference Include="SixLabors.ImageSharp" />
+	  <PackageReference Include="System.Data.SQLite" />
+	  <PackageReference Include="System.DirectoryServices.Protocols" />
+	  <PackageReference Include="System.Management" />
+	  <PackageReference Include="System.Security.Permissions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BLAZAMEmailMessage/BLAZAMEmailMessage.csproj
+++ b/BLAZAMEmailMessage/BLAZAMEmailMessage.csproj
@@ -13,27 +13,27 @@
   </ItemGroup>
 
   <ItemGroup>
-	  <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.22">
+	  <PackageReference Include="Microsoft.AspNetCore.Components" />
+	  <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+	  <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-	  <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.11" />
-	  <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.11" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-    <PackageReference Include="MudBlazor" Version="8.13.0" />
-    <PackageReference Include="MudBlazor.Markdown" Version="8.11.0" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.11" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.11" />
-    <PackageReference Include="System.Management" Version="9.0.11" />
-    <PackageReference Include="System.Security.Permissions" Version="9.0.11" />
+	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+	  <PackageReference Include="Microsoft.Extensions.Localization" />
+	  <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="MudBlazor" />
+    <PackageReference Include="MudBlazor.Markdown" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" />
+    <PackageReference Include="System.DirectoryServices.Protocols" />
+    <PackageReference Include="System.Management" />
+    <PackageReference Include="System.Security.Permissions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BLAZAMFileSystem/BLAZAMFileSystem.csproj
+++ b/BLAZAMFileSystem/BLAZAMFileSystem.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="9.0.11" />
-    <PackageReference Include="System.Security.Permissions" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" />
+    <PackageReference Include="System.Security.Permissions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BLAZAMGlobal/BLAZAMGlobal.csproj
+++ b/BLAZAMGlobal/BLAZAMGlobal.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/BLAZAMGoogleWorkspacePlugin/BLAZAMGoogleWorkspacePlugin.csproj
+++ b/BLAZAMGoogleWorkspacePlugin/BLAZAMGoogleWorkspacePlugin.csproj
@@ -15,11 +15,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis" Version="1.72.0" />
-    <PackageReference Include="Google.Apis.Admin.Directory.directory_v1" Version="1.72.0.3946" />
-    <PackageReference Include="Google.Apis.Auth" Version="1.72.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
+    <PackageReference Include="Google.Apis" />
+    <PackageReference Include="Google.Apis.Admin.Directory.directory_v1" />
+    <PackageReference Include="Google.Apis.Auth" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BLAZAMGui/BLAZAMGui.csproj
+++ b/BLAZAMGui/BLAZAMGui.csproj
@@ -28,31 +28,31 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DuoUniversal" Version="1.3.1" />
-		<PackageReference Include="MailKit" Version="4.14.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.22" />
-		<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.22" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-		<PackageReference Include="MudBlazor" Version="8.13.0" />
-		<PackageReference Include="MudBlazor.Markdown" Version="8.11.0" />
-		<PackageReference Include="Octokit" Version="14.0.0" />
-		<PackageReference Include="PreMailer.Net" Version="2.7.2" />
-		<PackageReference Include="Serilog" Version="4.3.0" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.11" />
-		<PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.11" />
-		<PackageReference Include="System.Drawing.Common" Version="9.0.11" />
-		<PackageReference Include="System.Management" Version="9.0.11" />
-		<PackageReference Include="System.Security.Permissions" Version="9.0.11" />
+		<PackageReference Include="DuoUniversal" />
+		<PackageReference Include="MailKit" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+		<PackageReference Include="Microsoft.AspNetCore.Components" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" />
+		<PackageReference Include="Microsoft.Extensions.Http" />
+		<PackageReference Include="Microsoft.Extensions.Localization" />
+		<PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="MudBlazor" />
+		<PackageReference Include="MudBlazor.Markdown" />
+		<PackageReference Include="Octokit" />
+		<PackageReference Include="PreMailer.Net" />
+		<PackageReference Include="Serilog" />
+		<PackageReference Include="Serilog.Extensions.Logging" />
+		<PackageReference Include="SixLabors.ImageSharp" />
+		<PackageReference Include="System.Diagnostics.PerformanceCounter" />
+		<PackageReference Include="System.DirectoryServices.Protocols" />
+		<PackageReference Include="System.Drawing.Common" />
+		<PackageReference Include="System.Management" />
+		<PackageReference Include="System.Security.Permissions" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/BLAZAMJobs/BLAZAMJobs.csproj
+++ b/BLAZAMJobs/BLAZAMJobs.csproj
@@ -8,28 +8,28 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.22">
+    <PackageReference Include="Microsoft.AspNetCore.Components" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-    <PackageReference Include="MudBlazor" Version="8.13.0" />
-    <PackageReference Include="MudBlazor.Markdown" Version="8.11.0" />
-    <PackageReference Include="PreMailer.Net" Version="2.7.2" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.11" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.11" />
-    <PackageReference Include="System.Management" Version="9.0.11" />
-    <PackageReference Include="System.Security.Permissions" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Localization" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="MudBlazor" />
+    <PackageReference Include="MudBlazor.Markdown" />
+    <PackageReference Include="PreMailer.Net" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" />
+    <PackageReference Include="System.DirectoryServices.Protocols" />
+    <PackageReference Include="System.Management" />
+    <PackageReference Include="System.Security.Permissions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BLAZAMLoggers/BLAZAMLogger.csproj
+++ b/BLAZAMLoggers/BLAZAMLogger.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
-    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="Serilog.Enrichers.Environment" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="Serilog.Sinks.Seq" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" />
   </ItemGroup>
 
 </Project>

--- a/BLAZAMNotifications/BLAZAMNotifications.csproj
+++ b/BLAZAMNotifications/BLAZAMNotifications.csproj
@@ -8,27 +8,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.22">
+    <PackageReference Include="Microsoft.AspNetCore.Components" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-    <PackageReference Include="MudBlazor" Version="8.13.0" />
-    <PackageReference Include="MudBlazor.Markdown" Version="8.11.0" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.11" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.11" />
-    <PackageReference Include="System.Management" Version="9.0.11" />
-    <PackageReference Include="System.Security.Permissions" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Localization" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="MudBlazor" />
+    <PackageReference Include="MudBlazor.Markdown" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" />
+    <PackageReference Include="System.DirectoryServices.Protocols" />
+    <PackageReference Include="System.Management" />
+    <PackageReference Include="System.Security.Permissions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BLAZAMServices/BLAZAMServices.csproj
+++ b/BLAZAMServices/BLAZAMServices.csproj
@@ -8,30 +8,30 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DuoUniversal" Version="1.3.1" />
-    <PackageReference Include="GoogleAuthenticator" Version="3.2.0" />
-    <PackageReference Include="MailKit" Version="4.14.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.22" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-    <PackageReference Include="MudBlazor" Version="8.13.0" />
-    <PackageReference Include="Octokit" Version="14.0.0" />
-    <PackageReference Include="PreMailer.Net" Version="2.7.2" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.11" />
-    <PackageReference Include="System.Management" Version="9.0.11" />
-    <PackageReference Include="System.Security.Permissions" Version="9.0.11" />
+    <PackageReference Include="DuoUniversal" />
+    <PackageReference Include="GoogleAuthenticator" />
+    <PackageReference Include="MailKit" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Localization" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="MudBlazor" />
+    <PackageReference Include="Octokit" />
+    <PackageReference Include="PreMailer.Net" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="System.DirectoryServices.Protocols" />
+    <PackageReference Include="System.Management" />
+    <PackageReference Include="System.Security.Permissions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BLAZAMSession/BLAZAMSession.csproj
+++ b/BLAZAMSession/BLAZAMSession.csproj
@@ -8,23 +8,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.22">
+    <PackageReference Include="Microsoft.AspNetCore.Components" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-    <PackageReference Include="MudBlazor.Markdown" Version="8.11.0" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.11" />
-    <PackageReference Include="System.Management" Version="9.0.11" />
-    <PackageReference Include="System.Security.Permissions" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="MudBlazor.Markdown" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="System.DirectoryServices.Protocols" />
+    <PackageReference Include="System.Management" />
+    <PackageReference Include="System.Security.Permissions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BLAZAMStatic/BLAZAMStatic.csproj
+++ b/BLAZAMStatic/BLAZAMStatic.csproj
@@ -8,23 +8,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.22">
+    <PackageReference Include="Microsoft.AspNetCore.Components" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-    <PackageReference Include="MudBlazor.Markdown" Version="8.11.0" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.11" />
-    <PackageReference Include="System.Management" Version="9.0.11" />
-    <PackageReference Include="System.Security.Permissions" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="MudBlazor.Markdown" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="System.DirectoryServices.Protocols" />
+    <PackageReference Include="System.Management" />
+    <PackageReference Include="System.Security.Permissions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BLAZAMThemes/BLAZAMThemes.csproj
+++ b/BLAZAMThemes/BLAZAMThemes.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-    <PackageReference Include="MudBlazor" Version="8.13.0" />
-    <PackageReference Include="MudBlazor.ThemeManager" Version="3.0.0" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.Extensions.Localization" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="MudBlazor" />
+    <PackageReference Include="MudBlazor.ThemeManager" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" />
   </ItemGroup>
 
 </Project>

--- a/BLAZAMUpdate/BLAZAMUpdate.csproj
+++ b/BLAZAMUpdate/BLAZAMUpdate.csproj
@@ -9,30 +9,30 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.22" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.22">
+		<PackageReference Include="Microsoft.AspNetCore.Components" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.11" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-		<PackageReference Include="MudBlazor" Version="8.13.0" />
-		<PackageReference Include="MudBlazor.Markdown" Version="8.11.0" />
-		<PackageReference Include="Octokit" Version="14.0.0" />
-		<PackageReference Include="PreMailer.Net" Version="2.7.2" />
-		<PackageReference Include="Serilog" Version="4.3.0" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="9.0.11" />
-		<PackageReference Include="System.DirectoryServices.Protocols" Version="9.0.11" />
-		<PackageReference Include="System.Drawing.Common" Version="9.0.11" />
-		<PackageReference Include="System.Management" Version="9.0.11" />
-		<PackageReference Include="System.Security.Permissions" Version="9.0.11" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" />
+		<PackageReference Include="Microsoft.Extensions.Http" />
+		<PackageReference Include="Microsoft.Extensions.Localization" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="MudBlazor" />
+		<PackageReference Include="MudBlazor.Markdown" />
+		<PackageReference Include="Octokit" />
+		<PackageReference Include="PreMailer.Net" />
+		<PackageReference Include="Serilog" />
+		<PackageReference Include="Serilog.Extensions.Logging" />
+		<PackageReference Include="SixLabors.ImageSharp" />
+		<PackageReference Include="System.Diagnostics.PerformanceCounter" />
+		<PackageReference Include="System.DirectoryServices.Protocols" />
+		<PackageReference Include="System.Drawing.Common" />
+		<PackageReference Include="System.Management" />
+		<PackageReference Include="System.Security.Permissions" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/BLAZAPluginTest/BLAZAMTestPlugin.csproj
+++ b/BLAZAPluginTest/BLAZAMTestPlugin.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,73 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="BlazorTemplater" Version="1.5.1" />
+    <PackageVersion Include="Cassia" Version="2.0.0.60" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
+    <PackageVersion Include="DuoUniversal" Version="1.3.1" />
+    <PackageVersion Include="Google.Apis" Version="1.72.0" />
+    <PackageVersion Include="Google.Apis.Admin.Directory.directory_v1" Version="1.72.0.3946" />
+    <PackageVersion Include="Google.Apis.Auth" Version="1.72.0" />
+    <PackageVersion Include="GoogleAuthenticator" Version="3.2.0" />
+    <PackageVersion Include="MailKit" Version="4.14.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.AspNetCore.ResponseCompression" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Localization" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.56.0" />
+    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.10" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="MudBlazor" Version="8.13.0" />
+    <PackageVersion Include="MudBlazor.Markdown" Version="8.11.0" />
+    <PackageVersion Include="MudBlazor.ThemeManager" Version="3.0.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="NUnit" Version="4.4.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageVersion Include="Octokit" Version="14.0.0" />
+    <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
+    <PackageVersion Include="PreMailer.Net" Version="2.7.2" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.2" />
+    <PackageVersion Include="Serilog.Sinks.Seq" Version="9.0.0" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.6" />
+    <PackageVersion Include="System.Data.SQLite" Version="2.0.2" />
+    <PackageVersion Include="System.Diagnostics.EventLog" Version="9.0.11" />
+    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="9.0.11" />
+    <PackageVersion Include="System.DirectoryServices" Version="9.0.11" />
+    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="9.0.11" />
+    <PackageVersion Include="System.DirectoryServices.Protocols" Version="9.0.11" />
+    <PackageVersion Include="System.Drawing.Common" Version="9.0.11" />
+    <PackageVersion Include="System.Management" Version="9.0.11" />
+    <PackageVersion Include="System.Security.Permissions" Version="9.0.11" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+</Project>

--- a/PlaywrightTests/PlaywrightTests.csproj
+++ b/PlaywrightTests/PlaywrightTests.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.56.0" />
+    <PackageReference Include="Microsoft.Playwright.NUnit" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Convert to NuGet Central Package Management (CPM)

## Summary

This PR migrates all 24 projects in the BLAZAM solution from per-project package versioning to [NuGet Central Package Management (CPM)](https://learn.microsoft.com/nuget/consume-packages/central-package-management). All 66 unique package versions are centralized into a single `Directory.Packages.props` file at the solution root, providing a single source of truth for package version governance.

## What Changed

- **Created `Directory.Packages.props`** at the solution root with `ManagePackageVersionsCentrally` set to `true` and 66 `PackageVersion` entries sorted alphabetically
- **Updated 22 project files** to remove `Version` attributes from all 349 `PackageReference` items
- **Preserved all existing attributes** — `PrivateAssets`, `IncludeAssets`, and other metadata on `PackageReference` items remain unchanged

## Conversion Metrics

| Metric | Value |
|--------|-------|
| Projects in solution | 24 |
| Project files modified | 22 |
| Unique packages centralized | 66 |
| `PackageReference` items updated | 349 |
| Version conflicts resolved | 0 |
| `VersionOverride` entries needed | 0 |
| Packages skipped | 0 |
| MSBuild version properties | 0 |

## Validation

- ✅ Baseline build succeeded before any changes (0 errors, 1139 pre-existing warnings)
- ✅ Post-conversion build succeeded (0 errors, 1139 warnings — identical to baseline)
- ✅ **Conversion is fully version-neutral** — all 349 resolved package versions are identical before and after conversion
- ✅ `Directory.Packages.props` exists with `ManagePackageVersionsCentrally` set to `true`
- ✅ Every in-scope `PackageReference` has no `Version` attribute
- ✅ Every referenced package has a corresponding `PackageVersion` entry

### Centralized Package Versions

The following 66 packages are now managed centrally in `Directory.Packages.props`. Future package version changes should be made in `Directory.Packages.props` only.

| Package | Version | Projects |
|---------|---------|----------|
| BlazorTemplater | 1.5.1 | 2 |
| Cassia | 2.0.0.60 | 2 |
| coverlet.collector | 6.0.4 | 3 |
| coverlet.msbuild | 6.0.4 | 2 |
| DuoUniversal | 1.3.1 | 3 |
| Google.Apis | 1.72.0 | 1 |
| Google.Apis.Admin.Directory.directory_v1 | 1.72.0.3946 | 1 |
| Google.Apis.Auth | 1.72.0 | 1 |
| GoogleAuthenticator | 3.2.0 | 1 |
| MailKit | 4.14.1 | 2 |
| Microsoft.AspNetCore.Authentication.JwtBearer | 8.0.22 | 3 |
| Microsoft.AspNetCore.Components | 8.0.22 | 17 |
| Microsoft.AspNetCore.Components.Web | 8.0.22 | 17 |
| Microsoft.AspNetCore.ResponseCompression | 2.3.0 | 1 |
| Microsoft.CodeAnalysis.Common | 4.9.2 | 3 |
| Microsoft.CodeAnalysis.CSharp | 4.9.2 | 3 |
| Microsoft.EntityFrameworkCore | 8.0.22 | 3 |
| Microsoft.EntityFrameworkCore.Analyzers | 8.0.22 | 8 |
| Microsoft.EntityFrameworkCore.Design | 8.0.22 | 3 |
| Microsoft.EntityFrameworkCore.Relational | 8.0.22 | 3 |
| Microsoft.EntityFrameworkCore.Sqlite | 8.0.22 | 12 |
| Microsoft.EntityFrameworkCore.SqlServer | 8.0.22 | 6 |
| Microsoft.EntityFrameworkCore.Tools | 8.0.22 | 11 |
| Microsoft.Extensions.Configuration.Binder | 9.0.11 | 16 |
| Microsoft.Extensions.Hosting | 9.0.11 | 5 |
| Microsoft.Extensions.Hosting.Abstractions | 9.0.11 | 2 |
| Microsoft.Extensions.Hosting.WindowsServices | 9.0.11 | 2 |
| Microsoft.Extensions.Http | 9.0.11 | 5 |
| Microsoft.Extensions.Http.Polly | 9.0.11 | 2 |
| Microsoft.Extensions.Localization | 9.0.11 | 10 |
| Microsoft.Extensions.Localization.Abstractions | 9.0.11 | 5 |
| Microsoft.Extensions.Logging.Abstractions | 9.0.11 | 16 |
| Microsoft.NET.Test.Sdk | 18.0.1 | 4 |
| Microsoft.Playwright.NUnit | 1.56.0 | 1 |
| Microsoft.PowerShell.SDK | 7.4.10 | 1 |
| Moq | 4.20.72 | 2 |
| MudBlazor | 8.13.0 | 12 |
| MudBlazor.Markdown | 8.11.0 | 9 |
| MudBlazor.ThemeManager | 3.0.0 | 2 |
| Newtonsoft.Json | 13.0.4 | 3 |
| NUnit | 4.4.0 | 1 |
| NUnit.Analyzers | 4.11.2 | 1 |
| NUnit3TestAdapter | 5.2.0 | 1 |
| Octokit | 14.0.0 | 5 |
| Polly.Contrib.WaitAndRetry | 1.1.1 | 1 |
| Pomelo.EntityFrameworkCore.MySql | 8.0.3 | 3 |
| PreMailer.Net | 2.7.2 | 7 |
| Serilog | 4.3.0 | 17 |
| Serilog.AspNetCore | 9.0.0 | 2 |
| Serilog.Enrichers.Environment | 3.0.1 | 1 |
| Serilog.Extensions.Logging | 9.0.2 | 17 |
| Serilog.Sinks.Seq | 9.0.0 | 1 |
| SixLabors.ImageSharp | 3.1.12 | 14 |
| Swashbuckle.AspNetCore | 9.0.6 | 2 |
| Swashbuckle.AspNetCore.SwaggerUI | 9.0.6 | 2 |
| System.Data.SQLite | 2.0.2 | 1 |
| System.Diagnostics.EventLog | 9.0.11 | 1 |
| System.Diagnostics.PerformanceCounter | 9.0.11 | 8 |
| System.DirectoryServices | 9.0.11 | 2 |
| System.DirectoryServices.AccountManagement | 9.0.11 | 4 |
| System.DirectoryServices.Protocols | 9.0.11 | 14 |
| System.Drawing.Common | 9.0.11 | 4 |
| System.Management | 9.0.11 | 14 |
| System.Security.Permissions | 9.0.11 | 15 |
| xunit | 2.9.3 | 3 |
| xunit.runner.visualstudio | 3.1.5 | 3 |
