### PR TITLE
Upgrade Swashbuckle & OpenAPI, update NuGet dependencies

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.1</AssemblyVersion>
-		<Version>2026.02.26.0011</Version>
+		<Version>2026.02.26.0132</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAM/Data/EnumSchemaFilter.cs
+++ b/BLAZAM/Data/EnumSchemaFilter.cs
@@ -1,7 +1,7 @@
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System.Reflection;
+using System.Text.Json.Nodes;
 
 namespace BLAZAM.Data
 {
@@ -14,25 +14,25 @@ namespace BLAZAM.Data
     public class EnumSchemaFilter : ISchemaFilter
     {
         /// <summary>
-        /// Modifies the provided <see cref="OpenApiSchema"/> to replace numeric enum values with their string names.
+        /// Modifies the provided <see cref="IOpenApiSchema"/> to replace numeric enum values with their string names.
         /// </summary>
         /// <remarks>This method is specifically designed to handle enum types. If the type in the
         /// <paramref name="context"/> is an enum, the numeric values in the <paramref name="schema"/> are replaced with
         /// the corresponding string names of the enum fields.</remarks>
         /// <param name="schema">The OpenAPI schema to be modified.</param>
         /// <param name="context">The context containing metadata about the schema, including the type being processed.</param>
-        public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+        public void Apply(IOpenApiSchema schema, SchemaFilterContext context) // <-- Note IOpenApiSchema
         {
-            if (context.Type.IsEnum)
+            // Cast to OpenApiSchema to access mutable properties like .Enum
+            if (context.Type.IsEnum && schema is OpenApiSchema concreteSchema)
             {
                 // Replace the numeric values in schema.Enum with string names
-                schema.Enum.Clear();
+                concreteSchema.Enum.Clear();
                 foreach (var field in context.Type.GetFields(BindingFlags.Public | BindingFlags.Static))
                 {
-                    schema.Enum.Add(new OpenApiString(field.Name));
+                    // Use JsonNode instead of the deprecated OpenApiString
+                    concreteSchema.Enum.Add(JsonValue.Create(field.Name));
                 }
-
-
             }
         }
     }

--- a/BLAZAM/ProgramHelpers.cs
+++ b/BLAZAM/ProgramHelpers.cs
@@ -22,7 +22,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using MudBlazor;
 using MudBlazor.Services;
 using Polly;
@@ -372,19 +372,23 @@ namespace BLAZAM
                     In = ParameterLocation.Header, // Location of the token
                     Type = SecuritySchemeType.Http, // Type of scheme
                     Scheme = JwtBearerDefaults.AuthenticationScheme, // Authentication scheme name ("Bearer")
-                    BearerFormat = "JWT", // Format hint
-                    Reference = new OpenApiReference // Reference for linking security requirements
-                    {
-                        Id = JwtBearerDefaults.AuthenticationScheme,
-                        Type = ReferenceType.SecurityScheme
-                    }
+                    BearerFormat = "JWT"
+                    // REMOVED: The 'Reference' property has been removed in Microsoft.OpenApi v2.x
                 };
+
                 c.SchemaFilter<EnumSchemaFilter>();
+
+                // Define the scheme ID we want to use (e.g., "Bearer")
+                string schemeId = JwtBearerDefaults.AuthenticationScheme;
+
                 // Add the security definition to Swagger
-                c.AddSecurityDefinition(jwtSecurityScheme.Reference.Id, jwtSecurityScheme);
+                c.AddSecurityDefinition(schemeId, jwtSecurityScheme);
+
                 // Add a security requirement globally (forces auth for all endpoints shown in Swagger UI)
-                c.AddSecurityRequirement(new OpenApiSecurityRequirement() {
-                    { jwtSecurityScheme, Array.Empty<string>() } // Link the requirement to the definition
+                // UPDATED: Now requires a delegate and uses OpenApiSecuritySchemeReference
+                c.AddSecurityRequirement(document => new OpenApiSecurityRequirement
+                {
+                    [new OpenApiSecuritySchemeReference(schemeId, document)] = Array.Empty<string>().ToList()
                 });
             });
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,68 +5,68 @@
   <ItemGroup>
     <PackageVersion Include="BlazorTemplater" Version="1.5.1" />
     <PackageVersion Include="Cassia" Version="2.0.0.60" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
+    <PackageVersion Include="coverlet.msbuild" Version="8.0.0" />
     <PackageVersion Include="DuoUniversal" Version="1.3.1" />
-    <PackageVersion Include="Google.Apis" Version="1.72.0" />
-    <PackageVersion Include="Google.Apis.Admin.Directory.directory_v1" Version="1.72.0.3946" />
-    <PackageVersion Include="Google.Apis.Auth" Version="1.72.0" />
+    <PackageVersion Include="Google.Apis" Version="1.73.0" />
+    <PackageVersion Include="Google.Apis.Admin.Directory.directory_v1" Version="1.73.0.4058" />
+    <PackageVersion Include="Google.Apis.Auth" Version="1.73.0" />
     <PackageVersion Include="GoogleAuthenticator" Version="3.2.0" />
-    <PackageVersion Include="MailKit" Version="4.14.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.22" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="8.0.22" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-    <PackageVersion Include="Microsoft.AspNetCore.ResponseCompression" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
+    <PackageVersion Include="MailKit" Version="4.15.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.24" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="8.0.24" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.24" />
+    <PackageVersion Include="Microsoft.AspNetCore.ResponseCompression" Version="2.3.9" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.22" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.22" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.22" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.22" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.22" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.22" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.22" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Localization" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.56.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.24" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.24" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.24" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.24" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.24" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.24" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.24" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Localization" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.13" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.58.0" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.10" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MudBlazor" Version="8.13.0" />
     <PackageVersion Include="MudBlazor.Markdown" Version="8.11.0" />
     <PackageVersion Include="MudBlazor.ThemeManager" Version="3.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NUnit" Version="4.4.0" />
+    <PackageVersion Include="NUnit" Version="4.5.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.2.0" />
     <PackageVersion Include="Octokit" Version="14.0.0" />
     <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
     <PackageVersion Include="PreMailer.Net" Version="2.7.2" />
-    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.2" />
     <PackageVersion Include="Serilog.Sinks.Seq" Version="9.0.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.6" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.4" />
     <PackageVersion Include="System.Data.SQLite" Version="2.0.2" />
-    <PackageVersion Include="System.Diagnostics.EventLog" Version="9.0.11" />
-    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="9.0.11" />
-    <PackageVersion Include="System.DirectoryServices" Version="9.0.11" />
-    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="9.0.11" />
-    <PackageVersion Include="System.DirectoryServices.Protocols" Version="9.0.11" />
-    <PackageVersion Include="System.Drawing.Common" Version="9.0.11" />
-    <PackageVersion Include="System.Management" Version="9.0.11" />
-    <PackageVersion Include="System.Security.Permissions" Version="9.0.11" />
+    <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.3" />
+    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.3" />
+    <PackageVersion Include="System.DirectoryServices" Version="10.0.3" />
+    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="10.0.3" />
+    <PackageVersion Include="System.DirectoryServices.Protocols" Version="10.0.3" />
+    <PackageVersion Include="System.Drawing.Common" Version="10.0.3" />
+    <PackageVersion Include="System.Management" Version="10.0.3" />
+    <PackageVersion Include="System.Security.Permissions" Version="10.0.3" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>


### PR DESCRIPTION
Updated Swashbuckle.AspNetCore to v10.x and migrated to Microsoft.OpenApi v2.x, refactoring EnumSchemaFilter and Swagger config for compatibility. Upgraded multiple NuGet packages (EF Core, MailKit, Google.Apis, Serilog, test tools) for improved security and features. Incremented app version to 2026.02.26.0132.