### PR TITLE
Bump AssemblyVersion to 1.5.2 in project file

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -5,7 +5,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
-		<AssemblyVersion>1.5.1</AssemblyVersion>
+		<AssemblyVersion>1.5.2</AssemblyVersion>
 		<Version>2026.02.26.0132</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>


### PR DESCRIPTION
Updated the AssemblyVersion in BLAZAM.csproj from 1.5.1 to 1.5.2 to reflect a new build or minor update. No other changes were made.