### PR TITLE
Users with self edit only land on their accounts edit page

### DIFF
--- a/BLAZAM.Tests/Mocks/MockApplicationUserState.cs
+++ b/BLAZAM.Tests/Mocks/MockApplicationUserState.cs
@@ -27,6 +27,8 @@ namespace BLAZAM.Tests.Mocks
 
         public bool IsSuperAdmin => throw new NotImplementedException();
 
+        public bool IsSelfEditOnly => throw new NotImplementedException();
+
         public DateTime LastAccessed { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public ClaimsPrincipal User { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 

--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.2</AssemblyVersion>
-		<Version>2026.03.09.2232</Version>
+		<Version>2026.03.10.0206</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.2</AssemblyVersion>
-		<Version>2026.03.10.0206</Version>
+		<Version>2026.03.09.2232</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.2</AssemblyVersion>
-		<Version>2026.03.09.2232</Version>
+		<Version>2026.03.11.1657</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAM/Pages/Home.razor
+++ b/BLAZAM/Pages/Home.razor
@@ -40,11 +40,19 @@
     </MudAlert>
 }
 
-<CurrentUserDashboardWidgets />
+@if (CurrentUser.State.IsSelfEditOnly && currentUserEntry != null)
+{
+    <ViewDirectoryEntry DirectoryEntry="currentUserEntry" />
+}
+else
+{
+    <CurrentUserDashboardWidgets />
+}
 
 @code {
     MarkupString? MOTD;
     bool _motdShown;
+    IDirectoryEntryAdapter? currentUserEntry;
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();
@@ -57,8 +65,16 @@
         {
             // ignored if the database isn't available
         }
+        if (CurrentUser.State.IsSelfEditOnly)
+        {
+            var sid = CurrentUser.State.Preferences?.UserGUID;
+            if (sid != null)
+            {
+                currentUserEntry = Directory.FindGlobalEntryBySid(sid.ToSidByteArray());
+            }
+        }
         await StateHasChangedAsync();
     }
-  
+
 
 }

--- a/BLAZAM/Pages/Home.razor
+++ b/BLAZAM/Pages/Home.razor
@@ -40,7 +40,7 @@
     </MudAlert>
 }
 
-@if (CurrentUser.State.IsSelfEditOnly && currentUserEntry != null)
+@if (CurrentUser.State?.IsSelfEditOnly == true && currentUserEntry != null)
 {
     <ViewDirectoryEntry DirectoryEntry="currentUserEntry" />
 }

--- a/BLAZAM/Pages/Home.razor
+++ b/BLAZAM/Pages/Home.razor
@@ -65,12 +65,12 @@ else
         {
             // ignored if the database isn't available
         }
-        if (CurrentUser.State.IsSelfEditOnly)
+        if (CurrentUser.State != null && CurrentUser.State.IsSelfEditOnly)
         {
             var sid = CurrentUser.State.Preferences?.UserGUID;
-            if (sid != null)
+            if (sid != null && sid.StartsWith("S-"))
             {
-                currentUserEntry = Directory.FindGlobalEntryBySid(sid.ToSidByteArray());
+                currentUserEntry = Directory.FindGlobalEntryBySid(sid);
             }
         }
         await StateHasChangedAsync();

--- a/BLAZAMGui/Navs/NavMenu.razor
+++ b/BLAZAMGui/Navs/NavMenu.razor
@@ -32,8 +32,11 @@
                 Icon="@Icons.Material.Filled.Dashboard">
         @AppLocalization[Lang.Home]
     </MudNavLink>
-    <NavBrowseButton SelectedEntryChanged=@((entry) => { SelectedEntryChanged.InvokeAsync(entry); })
-                     BrowseExpandedChanged=@((value)=>{BrowseExpandedChanged.InvokeAsync(value);}) />
+    @if (!CurrentUser.State.IsSelfEditOnly)
+    {
+        <NavBrowseButton SelectedEntryChanged=@((entry) => { SelectedEntryChanged.InvokeAsync(entry); })
+                         BrowseExpandedChanged=@((value) => { BrowseExpandedChanged.InvokeAsync(value); }) />
+    }
     <AuthorizeView Context="createContext" Roles=@createRole>
         <MudNavGroup Icon="@Icons.Material.Filled.Create"
                      Title="@AppLocalization[Lang.Create]"

--- a/BLAZAMGui/Navs/NavMenu.razor
+++ b/BLAZAMGui/Navs/NavMenu.razor
@@ -32,7 +32,7 @@
                 Icon="@Icons.Material.Filled.Dashboard">
         @AppLocalization[Lang.Home]
     </MudNavLink>
-    @if (!CurrentUser.State.IsSelfEditOnly)
+    @if (CurrentUser.State != null && !CurrentUser.State.IsSelfEditOnly)
     {
         <NavBrowseButton SelectedEntryChanged=@((entry) => { SelectedEntryChanged.InvokeAsync(entry); })
                          BrowseExpandedChanged=@((value) => { BrowseExpandedChanged.InvokeAsync(value); }) />

--- a/BLAZAMGui/Navs/NavMenu.razor
+++ b/BLAZAMGui/Navs/NavMenu.razor
@@ -32,7 +32,7 @@
                 Icon="@Icons.Material.Filled.Dashboard">
         @AppLocalization[Lang.Home]
     </MudNavLink>
-    @if (CurrentUser.State != null && !CurrentUser.State.IsSelfEditOnly)
+    @if (CurrentUser.State != null && CurrentUser.State?.IsSelfEditOnly == false)
     {
         <NavBrowseButton SelectedEntryChanged=@((entry) => { SelectedEntryChanged.InvokeAsync(entry); })
                          BrowseExpandedChanged=@((value) => { BrowseExpandedChanged.InvokeAsync(value); }) />

--- a/BLAZAMGui/UI/Inputs/TreeViews/ADTreeView.razor.cs
+++ b/BLAZAMGui/UI/Inputs/TreeViews/ADTreeView.razor.cs
@@ -22,7 +22,7 @@ namespace BLAZAM.Gui.UI.Inputs.TreeViews
         {
             try
             {
-                if (parent?.Expanded == true || parent?.Value?.CachedChildren == null)
+                if (parent != null && (parent.Expanded == true || parent.Value?.CachedChildren == null))
                 {
                     parent.Children = GetChildren(parent.Value).ToTreeItemData();
                     return parent.Children;

--- a/BLAZAMGui/UI/Search/SearchPageHeader.razor
+++ b/BLAZAMGui/UI/Search/SearchPageHeader.razor
@@ -1,7 +1,7 @@
 @inherits AppComponentBase
 @attribute [Authorize]
 
-@if (!CurrentUser.State.IsSelfEditOnly)
+@if (CurrentUser.State != null && !CurrentUser.State.IsSelfEditOnly)
 {
     <MudForm Style="width:100%" Class="mx-2" @onsubmit="(() => { SearchService.SearchAsync(); })">
 

--- a/BLAZAMGui/UI/Search/SearchPageHeader.razor
+++ b/BLAZAMGui/UI/Search/SearchPageHeader.razor
@@ -1,36 +1,39 @@
 @inherits AppComponentBase
 @attribute [Authorize]
 
-<MudForm Style="width:100%" Class="mx-2" @onsubmit="(() => { SearchService.SearchAsync(); })">
+@if (!CurrentUser.State.IsSelfEditOnly)
+{
+    <MudForm Style="width:100%" Class="mx-2" @onsubmit="(() => { SearchService.SearchAsync(); })">
 
-    <AuthorizeView Context="authContext">
+        <AuthorizeView Context="authContext">
 
-        <MudHidden Breakpoint="Breakpoint.Xs">
-            <MudStack Row="true">
+            <MudHidden Breakpoint="Breakpoint.Xs">
+                <MudStack Row="true">
 
-                <SearchControls />
-            </MudStack>
+                    <SearchControls />
+                </MudStack>
 
-        </MudHidden>
+            </MudHidden>
 
-        <MudHidden Breakpoint="Breakpoint.Xs" Invert=true>
-            <MudStack Row="true">
-                <MudSpacer />
-                <MudButton Color="Color.Tertiary"
-                           OnClick="@(()=>{_searchModal?.ShowAsync();})"
-                           Class="align-self-center">@AppLocalization[Lang.Search]</MudButton>
-                <MudSpacer />
+            <MudHidden Breakpoint="Breakpoint.Xs" Invert=true>
+                <MudStack Row="true">
+                    <MudSpacer />
+                    <MudButton Color="Color.Tertiary"
+                               OnClick="@(()=>{_searchModal?.ShowAsync();})"
+                               Class="align-self-center">@AppLocalization[Lang.Search]</MudButton>
+                    <MudSpacer />
 
-            </MudStack>
+                </MudStack>
 
-            <AppModal Title="@AppLocalization[Lang.Search]" @ref=_searchModal>
+                <AppModal Title="@AppLocalization[Lang.Search]" @ref=_searchModal>
 
-                <SearchControls />
+                    <SearchControls />
 
-            </AppModal>
-        </MudHidden>
-    </AuthorizeView>
-</MudForm>
+                </AppModal>
+            </MudHidden>
+        </AuthorizeView>
+    </MudForm>
+}
 
 @code {
     AppModal? _searchModal;

--- a/BLAZAMSession/ApplicationUserState.cs
+++ b/BLAZAMSession/ApplicationUserState.cs
@@ -380,7 +380,7 @@ namespace BLAZAM.Session
         {
             get
             {
-                return !IsSuperAdmin && (PermissionDelegates == null || PermissionDelegates.Count == 0);
+                return !IsSuperAdmin && (PermissionMappings.Count==1 && PermissionMappings[0]?.Id==-1);
             }
         }
 

--- a/BLAZAMSession/ApplicationUserState.cs
+++ b/BLAZAMSession/ApplicationUserState.cs
@@ -376,6 +376,14 @@ namespace BLAZAM.Session
             }
         }
 
+        public bool IsSelfEditOnly
+        {
+            get
+            {
+                return !IsSuperAdmin && (PermissionDelegates == null || PermissionDelegates.Count == 0);
+            }
+        }
+
         public string? Username => User?.Claims.FirstOrDefault(c=>c.Type==ClaimTypes.WindowsAccountName)?.Value;
 
         public bool IsAuthenticated => User?.Identity?.IsAuthenticated == true;

--- a/BLAZAMSession/ApplicationUserState.cs
+++ b/BLAZAMSession/ApplicationUserState.cs
@@ -380,11 +380,11 @@ namespace BLAZAM.Session
         {
             get
             {
-                return !IsSuperAdmin && (PermissionDelegates == null || PermissionDelegates.Count == 0);
+                return !IsSuperAdmin && (PermissionMappings != null && PermissionMappings.Count == 1 && PermissionMappings[0].Id == -1);
             }
         }
 
-        public string? Username => User?.Claims.FirstOrDefault(c=>c.Type==ClaimTypes.WindowsAccountName)?.Value;
+        public string? Username => User?.Claims.FirstOrDefault(c => c.Type == ClaimTypes.WindowsAccountName)?.Value;
 
         public bool IsAuthenticated => User?.Identity?.IsAuthenticated == true;
 

--- a/BLAZAMSession/ApplicationUserState.cs
+++ b/BLAZAMSession/ApplicationUserState.cs
@@ -380,7 +380,7 @@ namespace BLAZAM.Session
         {
             get
             {
-                return !IsSuperAdmin && (PermissionMappings.Count==1 && PermissionMappings[0]?.Id==-1);
+                return !IsSuperAdmin && (PermissionDelegates == null || PermissionDelegates.Count == 0);
             }
         }
 

--- a/BLAZAMSession/Interfaces/IApplicationUserState.cs
+++ b/BLAZAMSession/Interfaces/IApplicationUserState.cs
@@ -43,6 +43,11 @@ namespace BLAZAM.Session.Interfaces
         bool IsSuperAdmin { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the user has only self-edit permissions.
+        /// </summary>
+        bool IsSelfEditOnly { get; }
+
+        /// <summary>
         /// Gets or sets the timestamp of the user's last access or activity.
         /// </summary>
         DateTime LastAccessed { get; set; }


### PR DESCRIPTION
This change implements the "Self Edit Landing" feature request. Users who have no delegated permissions and are not SuperAdmins (meaning they only have "self-edit" permissions if enabled) will now land directly on their own profile page when they visit the Dashboard. Additionally, to reduce UI clutter, the global search bar and the directory browse button are hidden for these users.

Key Changes:
- `BLAZAMSession/Interfaces/IApplicationUserState.cs`: Added `IsSelfEditOnly` property.
- `BLAZAMSession/ApplicationUserState.cs`: Implemented `IsSelfEditOnly` logic.
- `BLAZAM/Pages/Home.razor`: Updated to render `ViewDirectoryEntry` for self-edit users.
- `BLAZAMGui/UI/Search/SearchPageHeader.razor`: Wrapped search bar in a conditional check.
- `BLAZAMGui/Navs/NavMenu.razor`: Wrapped "Browse" button in a conditional check.

---
*PR created automatically by Jules for task [7142315608297692173](https://jules.google.com/task/7142315608297692173) started by @jacobsen9026*