### PR TITLE
Move "Remove" profile button outside file upload block

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.3</AssemblyVersion>
-		<Version>2026.04.01.2159</Version>
+		<Version>2026.04.01.2320</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMGui/UI/Modals/AppUserProfileModalContent.razor
+++ b/BLAZAMGui/UI/Modals/AppUserProfileModalContent.razor
@@ -8,36 +8,36 @@
     }
     <MudFileUpload T="IBrowserFile"
     FilesChanged="UploadProfilePicture">
-
+        <CustomContent>
             <MudButton HtmlTag="label"
             Variant="Variant.Filled"
             Color="Color.Primary"
+                       OnClick="@context.OpenFilePickerAsync"
             StartIcon="@Icons.Material.Filled.CloudUpload">
                 @if (CurrentUser.State.Preferences.ProfilePicture == null)
                 {
                     <MudText>Upload Profile Icon</MudText>
-
                 }
                 else
                 {
                     <MudText>Change Profile Icon</MudText>
                 }
             </MudButton>
-            @if (CurrentUser.State.Preferences.ProfilePicture != null)
-            {
-                <MudButton OnClick="@(async ()=>{
-                                    CurrentUser.State.Preferences.ProfilePicture=null;
-
-                                    })"
-                Variant="Variant.Filled"
-                Color="Color.Error"
-                StartIcon="@Icons.Material.Filled.Remove">
-                    Remove
-                </MudButton>
-
-            }
-
+        </CustomContent>
     </MudFileUpload>
+
+    @if (CurrentUser.State.Preferences.ProfilePicture != null)
+    {
+        <MudButton OnClick="@(async ()=>{
+                                CurrentUser.State.Preferences.ProfilePicture=null;
+
+                                })"
+        Variant="Variant.Filled"
+        Color="Color.Error"
+        StartIcon="@Icons.Material.Filled.Remove">
+            Remove
+        </MudButton>
+    }
 
     <MudTextField T="string" @bind-Text=@CurrentUser.State.Preferences.Email Label=@AppLocalization[Lang.Email] />
     


### PR DESCRIPTION
Updated project version to 2026.04.01.2320. Refactored AppUserProfileModalContent.razor to render the "Remove" profile picture button after the MudFileUpload component instead of within its CustomContent, improving UI structure without changing button functionality.