### PR TITLE
Fix right-click context menus on dashboard data grids

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.3</AssemblyVersion>
-		<Version>2026.04.02.2230</Version>
+		<Version>2026.04.02.2248</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.3</AssemblyVersion>
-		<Version>2026.04.02.1635</Version>
+		<Version>2026.04.02.2206</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.3</AssemblyVersion>
-		<Version>2026.04.02.2206</Version>
+		<Version>2026.04.02.2230</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMGui/UI/Dashboard/Widgets/ChangedEntriesWidget.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/ChangedEntriesWidget.razor
@@ -18,6 +18,7 @@
              ColumnResizeMode="ResizeMode.Column"
              Virtualize=true
              Class="py-0"
+             RowContextMenuClick="@RowContextMenuClicked"
              SortMode="SortMode.Single">
     <Columns>
         <TemplateColumn Style="width:100px;" Title=@AppLocalization[Lang.Type]>
@@ -48,5 +49,5 @@
         <MudText>@AppLocalization[Lang.No_matching_results]</MudText>
     </NoRecordsContent>
 </MudDataGrid>
-
+<DirectoryEntryContextMenu @ref="_contextMenu"/>
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/ChangedEntriesWidget.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/ChangedEntriesWidget.razor
@@ -49,5 +49,5 @@
         <MudText>@AppLocalization[Lang.No_matching_results]</MudText>
     </NoRecordsContent>
 </MudDataGrid>
-<DirectoryEntryContextMenu @ref="_contextMenu"/>
+<DirectoryEntryContextMenu @ref="_contextMenu" OnChanged="@(()=>{InvokeStateHasChanged();})" />
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/ChangedPasswordsWidget.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/ChangedPasswordsWidget.razor
@@ -40,5 +40,5 @@
         <MudText>@AppLocalization[Lang.No_matching_results]</MudText>
     </NoRecordsContent>
 </MudDataGrid>
-<DirectoryEntryContextMenu @ref="_contextMenu" />
+<DirectoryEntryContextMenu @ref="_contextMenu" OnChanged="@(() => { InvokeStateHasChanged(); })" />
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/ChangedPasswordsWidget.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/ChangedPasswordsWidget.razor
@@ -15,6 +15,7 @@
              FilterMode="DataGridFilterMode.Simple"
              Loading=@LoadingData
              Square=true
+             RowContextMenuClick="@RowContextMenuClicked"
              ColumnResizeMode="ResizeMode.Column"
              Virtualize=true
              Class="py-0"
@@ -39,5 +40,5 @@
         <MudText>@AppLocalization[Lang.No_matching_results]</MudText>
     </NoRecordsContent>
 </MudDataGrid>
-
+<DirectoryEntryContextMenu @ref="_contextMenu" />
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/LockedOutUsers.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/LockedOutUsers.razor
@@ -14,6 +14,7 @@
              Virtualize
              RowClass="cursor-pointer"
              RowClick=@GoTo
+             RowContextMenuClick="@RowContextMenuClicked"
              Class="py-0"
              SortMode="SortMode.Single">
     <Columns>
@@ -39,5 +40,6 @@
         <MudText>@AppLocalization[Lang.No_user_are_locked_out]</MudText>
     </NoRecordsContent>
 </MudDataGrid>
+<DirectoryEntryContextMenu @ref="_contextMenu" />
 
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/LockedOutUsers.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/LockedOutUsers.razor
@@ -40,6 +40,6 @@
         <MudText>@AppLocalization[Lang.No_user_are_locked_out]</MudText>
     </NoRecordsContent>
 </MudDataGrid>
-<DirectoryEntryContextMenu @ref="_contextMenu" />
+<DirectoryEntryContextMenu @ref="_contextMenu" OnChanged="@(() => { InvokeStateHasChanged(); })" />
 
 

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewEntriesWidgetDataGrid.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewEntriesWidgetDataGrid.razor
@@ -52,8 +52,10 @@
 
     protected async Task RowContextMenuClicked<T>(DataGridRowClickEventArgs<T> args) where T : IDirectoryEntryAdapter
     {
-        _contextMenu?.SetEntry(args.Item);
-        _contextMenu?.OpenMenuAsync(args.MouseEventArgs);
+        if(_contextMenu == null)
+            return;
+        _contextMenu.SetEntry(args.Item);
+        await _contextMenu.OpenMenuAsync(args.MouseEventArgs);
     }
 
 }

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewEntriesWidgetDataGrid.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewEntriesWidgetDataGrid.razor
@@ -14,6 +14,7 @@
              Virtualize=false
              RowClass="cursor-pointer"
              RowClick=@RowClick
+             RowContextMenuClick="@RowContextMenuClicked"
              RowsPerPageChanged="@RowsPerPageChanged"
              Class="py-0"
              SortMode="SortMode.Single">
@@ -40,10 +41,19 @@
         <MudText>@AppLocalization[Lang.No_matching_results]</MudText>
     </NoRecordsContent>
 </MudDataGrid>
+<DirectoryEntryContextMenu @ref="_contextMenu" />
 
 
 @code {
+    private DirectoryEntryContextMenu? _contextMenu;
 
     [Parameter]
     public EventCallback OnChanged { get; set; }
+
+    protected async Task RowContextMenuClicked<T>(DataGridRowClickEventArgs<T> args) where T : IDirectoryEntryAdapter
+    {
+        _contextMenu?.SetEntry(args.Item);
+        _contextMenu?.OpenMenuAsync(args.MouseEventArgs);
+    }
+
 }

--- a/BLAZAMGui/UI/Dashboard/Widgets/NewEntriesWidgetDataGrid.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/NewEntriesWidgetDataGrid.razor
@@ -41,7 +41,7 @@
         <MudText>@AppLocalization[Lang.No_matching_results]</MudText>
     </NoRecordsContent>
 </MudDataGrid>
-<DirectoryEntryContextMenu @ref="_contextMenu" />
+<DirectoryEntryContextMenu @ref="_contextMenu" OnChanged="OnChanged" />
 
 
 @code {

--- a/BLAZAMGui/UI/Dashboard/Widgets/StaleEntriesWidgetDataGrid.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/StaleEntriesWidgetDataGrid.razor
@@ -14,6 +14,7 @@
              Virtualize=true
              RowClass="cursor-pointer"
              RowClick=@RowClick
+             RowContextMenuClick="@RowContextMenuClicked"
              RowsPerPageChanged="@RowsPerPageChanged"
              Class="py-0"
              SortMode="SortMode.Single">
@@ -41,10 +42,11 @@
         <MudText>@AppLocalization[Lang.No_matching_results]</MudText>
     </NoRecordsContent>
 </MudDataGrid>
+<DirectoryEntryContextMenu @ref="_contextMenu" />
 
 
 @code {
-
+    private DirectoryEntryContextMenu? _contextMenu;
     [Parameter]
     public EventCallback OnChanged { get; set; }
 
@@ -55,4 +57,10 @@
             return item.LastLogonTime?.ToLocalTime().ToString();
         });
     }
+    protected async Task RowContextMenuClicked<T>(DataGridRowClickEventArgs<T> args) where  T : IDirectoryEntryAdapter
+    {
+        _contextMenu?.SetEntry(args.Item);
+        _contextMenu?.OpenMenuAsync(args.MouseEventArgs);
+    }
+
 }

--- a/BLAZAMGui/UI/Dashboard/Widgets/StaleEntriesWidgetDataGrid.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/StaleEntriesWidgetDataGrid.razor
@@ -42,7 +42,7 @@
         <MudText>@AppLocalization[Lang.No_matching_results]</MudText>
     </NoRecordsContent>
 </MudDataGrid>
-<DirectoryEntryContextMenu @ref="_contextMenu" />
+<DirectoryEntryContextMenu @ref="_contextMenu" OnChanged="OnChanged" />
 
 
 @code {

--- a/BLAZAMGui/UI/Dashboard/Widgets/StaleEntriesWidgetDataGrid.razor
+++ b/BLAZAMGui/UI/Dashboard/Widgets/StaleEntriesWidgetDataGrid.razor
@@ -59,8 +59,10 @@
     }
     protected async Task RowContextMenuClicked<T>(DataGridRowClickEventArgs<T> args) where  T : IDirectoryEntryAdapter
     {
-        _contextMenu?.SetEntry(args.Item);
-        _contextMenu?.OpenMenuAsync(args.MouseEventArgs);
+        if (_contextMenu == null)
+            return;
+        _contextMenu.SetEntry(args.Item);
+        await _contextMenu.OpenMenuAsync(args.MouseEventArgs);
     }
 
 }

--- a/BLAZAMGui/UI/Dashboard/Widgets/Widget.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/Widget.cs
@@ -89,14 +89,18 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
 
         protected async Task RowContextMenuClicked(DataGridRowClickEventArgs<IDirectoryEntryAdapter> args)
         {
-            _contextMenu?.SetEntry(args.Item);
-            _contextMenu?.OpenMenuAsync(args.MouseEventArgs);
+            if (_contextMenu == null)
+                return;
+            _contextMenu.SetEntry(args.Item);
+            await _contextMenu.OpenMenuAsync(args.MouseEventArgs);
         }
 
         protected async Task RowContextMenuClicked(DataGridRowClickEventArgs<IADUser> args)
         {
-            _contextMenu?.SetEntry(args.Item);
-            _contextMenu?.OpenMenuAsync(args.MouseEventArgs);
+            if (_contextMenu == null)
+                return;
+            _contextMenu.SetEntry(args.Item);
+            await _contextMenu.OpenMenuAsync(args.MouseEventArgs);
         }
 
     }

--- a/BLAZAMGui/UI/Dashboard/Widgets/Widget.cs
+++ b/BLAZAMGui/UI/Dashboard/Widgets/Widget.cs
@@ -1,3 +1,4 @@
+using BLAZAM.Gui.UI.Inputs;
 using MudBlazor;
 
 namespace BLAZAM.Gui.UI.Dashboard.Widgets
@@ -19,6 +20,7 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
         [CascadingParameter]
         public CurrentUserDashboardWidgets CurrentUserDashboardWidgets { get; set; }
 
+        protected DirectoryEntryContextMenu? _contextMenu;
 
         protected override async Task OnInitializedAsync()
         {
@@ -83,6 +85,18 @@ namespace BLAZAM.Gui.UI.Dashboard.Widgets
             {
                 Loggers.SystemLogger.Error(ex,"Error attempting to set a widgets rows per page preference.");
             }
+        }
+
+        protected async Task RowContextMenuClicked(DataGridRowClickEventArgs<IDirectoryEntryAdapter> args)
+        {
+            _contextMenu?.SetEntry(args.Item);
+            _contextMenu?.OpenMenuAsync(args.MouseEventArgs);
+        }
+
+        protected async Task RowContextMenuClicked(DataGridRowClickEventArgs<IADUser> args)
+        {
+            _contextMenu?.SetEntry(args.Item);
+            _contextMenu?.OpenMenuAsync(args.MouseEventArgs);
         }
 
     }

--- a/BLAZAMGui/UI/DataGrids/DirectoryEntryDataGrid.razor
+++ b/BLAZAMGui/UI/DataGrids/DirectoryEntryDataGrid.razor
@@ -43,7 +43,7 @@
         <MudText>@NoResultsMessage</MudText>
     </NoRecordsContent>
 </MudDataGrid>
-<DirectoryEntryContextMenu @ref="_contextMenu" />
+<DirectoryEntryContextMenu @ref="_contextMenu" OnChanged="@(() => { InvokeStateHasChanged(); })" />
 @code {
     private DirectoryEntryContextMenu? _contextMenu;
 

--- a/BLAZAMGui/UI/DataGrids/DirectoryEntryDataGrid.razor
+++ b/BLAZAMGui/UI/DataGrids/DirectoryEntryDataGrid.razor
@@ -12,6 +12,7 @@
              Square=true
              ColumnResizeMode="ResizeMode.Column"
              Virtualize=true
+             RowContextMenuClick="@RowContextMenuClicked"
              Class="py-0"
              SortMode="SortMode.Single">
     <Columns>
@@ -42,8 +43,10 @@
         <MudText>@NoResultsMessage</MudText>
     </NoRecordsContent>
 </MudDataGrid>
-
+<DirectoryEntryContextMenu @ref="_contextMenu" />
 @code {
+    private DirectoryEntryContextMenu? _contextMenu;
+
     [Parameter] 
     public EventCallback<DataGridRowClickEventArgs<IDirectoryEntryAdapter>> RowClicked { get; set; }
 
@@ -64,4 +67,11 @@
 
     [Parameter]
     public EventCallback EntryChanged{ get; set; }
+
+    protected async Task RowContextMenuClicked(DataGridRowClickEventArgs<IDirectoryEntryAdapter> args)
+    {
+        _contextMenu?.SetEntry(args.Item);
+        _contextMenu?.OpenMenuAsync(args.MouseEventArgs);
+    }
+
 }

--- a/BLAZAMGui/UI/DataGrids/DirectoryEntryDataGrid.razor
+++ b/BLAZAMGui/UI/DataGrids/DirectoryEntryDataGrid.razor
@@ -70,8 +70,10 @@
 
     protected async Task RowContextMenuClicked(DataGridRowClickEventArgs<IDirectoryEntryAdapter> args)
     {
-        _contextMenu?.SetEntry(args.Item);
-        _contextMenu?.OpenMenuAsync(args.MouseEventArgs);
+        if (_contextMenu == null)
+            return;
+        _contextMenu.SetEntry(args.Item);
+        await _contextMenu.OpenMenuAsync(args.MouseEventArgs);
     }
 
 }

--- a/BLAZAMGui/UI/Inputs/DirectoryEntryContextMenu.razor
+++ b/BLAZAMGui/UI/Inputs/DirectoryEntryContextMenu.razor
@@ -9,6 +9,10 @@
 
     </ChildContent>
     <MenuContents>
+        <MudMenuItem Target="_blank" Href="@Entry.SearchUri"
+                     Icon="@Icons.Material.Outlined.OpenInNew">
+            @AppLocalization[Lang.Open_In_New_Tab]
+        </MudMenuItem>
         @if (Entry is IAccountDirectoryAdapter account && !Disabled)
         {
             @if (account.CanUnlock && account.LockedOut)
@@ -19,14 +23,14 @@
                 </MudMenuItem>
 
             }
-            @if (account.Enabled)
+            @if (account.CanDisable && account.Enabled)
             {
                 <MudMenuItem OnClick="(async () => { await DisableAccount(account); })"
                              Icon="@Icons.Material.Outlined.Cancel">
                     @AppLocalization[Lang.Disable] @AppLocalization[account.ObjectType.ToString()]
                 </MudMenuItem>
             }
-            @if (account.Disabled)
+            @if (account.CanEnable && account.Disabled)
             {
                 <MudMenuItem OnClick="(async () => { await EnableAccount(account); })"
                              Icon="@Icons.Material.Outlined.Check">

--- a/BLAZAMGui/UI/Inputs/DirectoryEntryContextMenu.razor
+++ b/BLAZAMGui/UI/Inputs/DirectoryEntryContextMenu.razor
@@ -1,18 +1,19 @@
 ﻿@using BLAZAM.Global.Events
 @inherits AppComponentBase
-@if (Entry is IAccountDirectoryAdapter account && !Disabled)
-{
-    <MudContextMenu>
 
-        <ChildContent>
+<MudContextMenu @ref="_menu">
 
-            @ChildContent
+    <ChildContent>
 
-        </ChildContent>
-        <MenuContents>
+        @ChildContent
+
+    </ChildContent>
+    <MenuContents>
+        @if (Entry is IAccountDirectoryAdapter account && !Disabled)
+        {
             @if (account.CanUnlock && account.LockedOut)
             {
-                <MudMenuItem OnClick="(async()=>{await UnlockAccount(account);})"
+                <MudMenuItem OnClick="(async () => { await UnlockAccount(account); })"
                              Icon="@Icons.Material.Outlined.LockOpen">
                     @AppLocalization[Lang.Unlock] @AppLocalization[account.ObjectType.ToString()]
                 </MudMenuItem>
@@ -20,27 +21,26 @@
             }
             @if (account.Enabled)
             {
-                <MudMenuItem OnClick="(async()=>{await DisableAccount(account);})"
+                <MudMenuItem OnClick="(async () => { await DisableAccount(account); })"
                              Icon="@Icons.Material.Outlined.Cancel">
                     @AppLocalization[Lang.Disable] @AppLocalization[account.ObjectType.ToString()]
                 </MudMenuItem>
             }
             @if (account.Disabled)
             {
-                <MudMenuItem OnClick="(async()=>{await EnableAccount(account);})"
+                <MudMenuItem OnClick="(async () => { await EnableAccount(account); })"
                              Icon="@Icons.Material.Outlined.Check">
                     @AppLocalization[Lang.Enable] @AppLocalization[account.ObjectType.ToString()]
                 </MudMenuItem>
             }
-        </MenuContents>
-    </MudContextMenu>
-}
-else
-{
-    @ChildContent
-}
+        }
+
+    </MenuContents>
+</MudContextMenu>
 
 @code {
+    private MudContextMenu? _menu;
+
     [Parameter]
     public RenderFragment ChildContent { get; set; }
     [Parameter]
@@ -59,13 +59,13 @@ else
 
             var unlockJob = await userToUnlock.CommitChangesAsync();
             ApplicationEvents.DirectoryEntryEvent.Invoke(new()
-                {
-                    EventType = ApplicationEventType.Modify,
-                    Entry = userToUnlock,
-                    Changes = changes,
-                    Actor = CurrentUser.State
+            {
+                EventType = ApplicationEventType.Modify,
+                Entry = userToUnlock,
+                Changes = changes,
+                Actor = CurrentUser.State
 
-                });
+            });
             if (unlockJob.Result == JobResult.Passed)
             {
 
@@ -89,13 +89,13 @@ else
 
             var unlockJob = await userToUnlock.CommitChangesAsync();
             ApplicationEvents.DirectoryEntryEvent.Invoke(new()
-                {
-                    EventType = ApplicationEventType.Modify,
-                    Entry = userToUnlock,
-                    Changes = changes,
-                    Actor = CurrentUser.State
+            {
+                EventType = ApplicationEventType.Modify,
+                Entry = userToUnlock,
+                Changes = changes,
+                Actor = CurrentUser.State
 
-                });
+            });
             if (unlockJob.Result == JobResult.Passed)
             {
 
@@ -120,13 +120,13 @@ else
 
             var unlockJob = await userToUnlock.CommitChangesAsync();
             ApplicationEvents.DirectoryEntryEvent.Invoke(new()
-                {
-                    EventType = ApplicationEventType.Modify,
-                    Entry = userToUnlock,
-                    Changes = changes,
-                    Actor = CurrentUser.State
+            {
+                EventType = ApplicationEventType.Modify,
+                Entry = userToUnlock,
+                Changes = changes,
+                Actor = CurrentUser.State
 
-                });
+            });
 
             if (unlockJob.Result == JobResult.Passed)
             {
@@ -140,5 +140,16 @@ else
                 SnackBarService.Error("Could not disable: " + unlockJob.Exception?.Message);
             }
         }
+    }
+    public async Task OpenMenuAsync(MouseEventArgs args)
+    {
+        if (!Disabled && _menu != null)
+        {
+            await _menu.OpenMenuAsync(args);
+        }
+    }
+    public void SetEntry(IDirectoryEntryAdapter entry)
+    {
+        Entry = entry;
     }
 }

--- a/BLAZAMGui/UI/Inputs/MudContextMenu.razor
+++ b/BLAZAMGui/UI/Inputs/MudContextMenu.razor
@@ -1,8 +1,12 @@
 ﻿
-<MudMenu Dense=true
+<MudMenu @ref="_menu" FullWidth=true
+    PositionAtCursor="true"
+         Dense=true
          ActivationEvent=MouseEvent.RightClick>
     <ActivatorContent>
-        <div @onclick="@(() => context.ToggleAsync())" class="pa-0 ma-0 ">
+        <div @onclick="@(() => {
+context.ToggleAsync();
+})" class="pa-0 ma-0 ">
             @if (Text != null)
             {
                 @Text
@@ -15,11 +19,24 @@
 
     </ChildContent>
 </MudMenu>
-@code { [Parameter]
+@code {
+
+
+    [Parameter]
     public RenderFragment ChildContent { get; set; }
     [Parameter]
     public string? Text { get; set; } = null;
     [Parameter]
     public RenderFragment MenuContents { get; set; }
+
+    private MudMenu? _menu;
+
+    public async Task OpenMenuAsync(MouseEventArgs args)
+    {
+        if (_menu != null)
+        {
+            await _menu.OpenMenuAsync(args);
+        }
+    }
 }
 

--- a/BLAZAMGui/UI/Outputs/DemoHelpAlert.razor
+++ b/BLAZAMGui/UI/Outputs/DemoHelpAlert.razor
@@ -57,9 +57,10 @@
                     await Task.Delay(100);
                 }
                 randomUsers = foundResults;
-                LoadingData = false;
-                await StateHasChangedAsync();
+                
             }
+            LoadingData = false;
+            await StateHasChangedAsync();
         });
        
     }

--- a/BLAZAMGui/UI/Outputs/DirectoryEntryLink.razor
+++ b/BLAZAMGui/UI/Outputs/DirectoryEntryLink.razor
@@ -1,11 +1,8 @@
 ﻿@inherits AppComponentBase
 <DirectoryEntryTooltipPopover Entry="@Entry">
-    <DirectoryEntryContextMenu Entry="@Entry"
-                               OnChanged="OnChanged">
 
             <MudText Class="@Class" Align="@Align" Style="@Style" Color="@Color">@(Entry!=null?Entry.CanonicalName:Sid)</MudText>
         
-    </DirectoryEntryContextMenu>
 </DirectoryEntryTooltipPopover>
 
 @code {

--- a/BLAZAMGui/UI/Outputs/OUBreadcrumbs.razor
+++ b/BLAZAMGui/UI/Outputs/OUBreadcrumbs.razor
@@ -20,6 +20,8 @@
 
 
 @code {
+    private object _lock = new();
+
     [Parameter]
     public IDirectoryEntryAdapter? Entry { get; set; }
     private List<BreadcrumbItem> _items = new();
@@ -37,19 +39,23 @@
                 if (ou is not null)
                 {
                     IADOrganizationalUnit? ouCursor = ou;
-                    do
+                    lock (_lock)
                     {
-                        if (ouCursor.Name is not null)
+                        do
                         {
-                            items.Add(new BreadcrumbItem(ouCursor.Name, ouCursor.SearchUri));
-                        }
-                        else
-                        {
-                            Loggers.ActiveDirectoryLogger.Information("OU with null name found in breadcrumb generation for {@Entry}", Entry.DN);
-                        }
-                        ouCursor = await ouCursor.GetParentAsync() as IADOrganizationalUnit;
+                            if (ouCursor.Name is not null)
+                            {
+                                items.Add(new BreadcrumbItem(ouCursor.Name, ouCursor.SearchUri));
+                            }
+                            else
+                            {
+                                Loggers.ActiveDirectoryLogger.Information("OU with null name found in breadcrumb generation for {@Entry}", Entry.DN);
+                            }
+                            ouCursor = ouCursor.GetParent() as IADOrganizationalUnit;
 
-                    } while (ouCursor != null);
+                        } while (ouCursor != null);
+                    }
+               
                 }
                 items.Reverse();
                 _items = items;

--- a/BLAZAMLocalization/Lang.cs
+++ b/BLAZAMLocalization/Lang.cs
@@ -133,6 +133,7 @@
         public static readonly string Home_Directory = "Home Directory";
         public static readonly string Home_Drive = "Home Drive";
         public static readonly string Script_Path = "Script Path";
+        public static readonly string Open_In_New_Tab = "Open In New Tab";
         public static readonly string Profile_Path = "Profile Path";
         public static readonly string Telephone_Number = "Telephone Number";
         public static readonly string System_Settings = "System Settings";


### PR DESCRIPTION
Implemented RowContextMenuClick support for directory entry data grids and widgets, enabling context menus on right-click. Refactored DirectoryEntryContextMenu and MudContextMenu to allow programmatic opening at cursor position. Improved code structure and thread safety in OUBreadcrumbs. Updated project version to 2026.04.02.2206.