### PR TITLE
Refactor Audit Components with Shared Base Class

### DIFF
--- a/BLAZAMGui/UI/Settings/Audit/AuditContentBase.cs
+++ b/BLAZAMGui/UI/Settings/Audit/AuditContentBase.cs
@@ -1,0 +1,28 @@
+using BLAZAM.Database.Context;
+using Microsoft.AspNetCore.Components;
+using Microsoft.EntityFrameworkCore;
+
+namespace BLAZAM.Gui.UI.Settings.Audit
+{
+    public abstract class AuditContentBase<T> : DatabaseComponentBase
+    {
+        protected DateTime? StartDate { get; set; } = DateTime.Today.AddDays(-7);
+        protected DateTime? EndDate { get; set; } = DateTime.Today;
+        protected List<T> auditEntries = new();
+
+        protected override async Task OnInitializedAsync()
+        {
+            await base.OnInitializedAsync();
+            await FetchData();
+        }
+
+        protected virtual async Task TimeframeChanged((DateTime? start, DateTime? end) dates)
+        {
+            StartDate = dates.start;
+            EndDate = dates.end;
+            await FetchData();
+        }
+
+        protected abstract Task FetchData();
+    }
+}

--- a/BLAZAMGui/UI/Settings/Audit/EmailAuditContent.razor
+++ b/BLAZAMGui/UI/Settings/Audit/EmailAuditContent.razor
@@ -1,6 +1,6 @@
 @using BLAZAM.Database.Models.Audit
 @using BLAZAM.Gui.UI.Shared
-@inherits DatabaseComponentBase
+@inherits AuditContentBase<EmailAuditLog>
 <TimeframeSelector OnTimeframeChanged="TimeframeChanged" />
 <MudDataGrid ColumnResizeMode="ResizeMode.Container"
              FixedHeader=true
@@ -8,7 +8,7 @@
              Hideable=true
              RowClass="cursor-pointer"
              RowClick="@(async (DataGridRowClickEventArgs<EmailAuditLog> args)=>{emailToPreview = args.Item;await bodyModal.ShowAsync();})"
-             Items="@_attempts"
+             Items="@auditEntries"
              Filterable="true"
              SortMode="@SortMode.Multiple"
              Groupable="false">
@@ -82,27 +82,13 @@
     </AppModal>
 
 @code {
-    private DateTime? StartDate = DateTime.Today.AddDays(-7);
-    private DateTime? EndDate = DateTime.Today;
     AppModal bodyModal;
     EmailAuditLog? emailToPreview = null;
-    private List<EmailAuditLog> _attempts = new();
-    protected override async Task OnInitializedAsync()
+    protected override async Task FetchData()
     {
-        await base.OnInitializedAsync();
-        await GetAttempts(StartDate,EndDate);
-    }
-    private async Task TimeframeChanged((DateTime? start, DateTime? end) dates)
-    {
-        StartDate = dates.start;
-        EndDate = dates.end;
-        await GetAttempts(StartDate, EndDate);
-    }
-    private async Task GetAttempts(DateTime? startDate, DateTime? endDate)
-    {
-        if (startDate == null || endDate == null) return;
-        _attempts = await Context.EmailAuditLog.Where(e=>e.LastAttemptTimestamp>=startDate && e.LastAttemptTimestamp<endDate.Value.AddDays(1)).OrderByDescending(e => e.LastAttemptTimestamp).ToListAsync();
-        await StateHasChangedAsync();
+        if (StartDate == null || EndDate == null) return;
+        auditEntries = await Context.EmailAuditLog.Where(e => e.LastAttemptTimestamp >= StartDate && e.LastAttemptTimestamp < EndDate.Value.AddDays(1)).OrderByDescending(e => e.LastAttemptTimestamp).ToListAsync();
+        await InvokeAsync(StateHasChanged);
     }
 }
 

--- a/BLAZAMGui/UI/Settings/Audit/LoginAuditContent.razor
+++ b/BLAZAMGui/UI/Settings/Audit/LoginAuditContent.razor
@@ -1,4 +1,5 @@
-﻿@inherits DatabaseComponentBase
+﻿@using BLAZAM.Database.Models.Audit
+@inherits AuditContentBase<LogonAuditLog>
 
 <TimeframeSelector OnTimeframeChanged="TimeframeChanged" 
     StartDate="StartDate" 
@@ -13,7 +14,7 @@
                  FixedHeader=true
                  ColumnResizeMode="ResizeMode.Container"
                  Hideable=true
-                 Items="@logonEntries.OrderByDescending(ae => ae.Timestamp)"
+                 Items="@auditEntries.OrderByDescending(ae => ae.Timestamp)"
                  Filterable="false"
                  SortMode="@SortMode.Multiple"
                  Groupable="false">
@@ -48,29 +49,28 @@
 
 @code {
     private LoginHistoryChart? _loginHistoryChart;
-    private List<LogonAuditLog> logonEntries = new();
-    private DateTime? StartDate = DateTime.Today.AddDays(-14);
-    private DateTime? EndDate = DateTime.Today;
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
-        await base.OnInitializedAsync();
-        await GetAttempts(StartDate, EndDate);
+        base.OnInitialized();
+        StartDate = DateTime.Today.AddDays(-14);
     }
-    private async Task TimeframeChanged((DateTime? start, DateTime? end) dates)
+
+    protected override async Task TimeframeChanged((DateTime? start, DateTime? end) dates)
     {
         if (_loginHistoryChart != null)
         {
-            _loginHistoryChart.StartDate = dates.start; 
+            _loginHistoryChart.StartDate = dates.start;
             _loginHistoryChart.EndDate = dates.end;
             await _loginHistoryChart.GenerateLoginSeries();
         }
-        await GetAttempts(dates.start, dates.end);
+        await base.TimeframeChanged(dates);
     }
-    private async Task GetAttempts(DateTime? startDate, DateTime? endDate)
+
+    protected override async Task FetchData()
     {
-        if (startDate == null || endDate == null) return;
-        logonEntries = await Context.LogonAuditLog.Where(e => e.Timestamp >= startDate && e.Timestamp < endDate.Value.AddDays(1)).OrderByDescending(e => e.Timestamp).ToListAsync();
-        await StateHasChangedAsync();
+        if (StartDate == null || EndDate == null) return;
+        auditEntries = await Context.LogonAuditLog.Where(e => e.Timestamp >= StartDate && e.Timestamp < EndDate.Value.AddDays(1)).OrderByDescending(e => e.Timestamp).ToListAsync();
+        await InvokeAsync(StateHasChanged);
     }
 }

--- a/BLAZAMGui/UI/Settings/Audit/MainAuditContent.razor
+++ b/BLAZAMGui/UI/Settings/Audit/MainAuditContent.razor
@@ -1,6 +1,6 @@
 ﻿@using BLAZAM.Database.Models.Audit
 @using BLAZAM.Gui.UI.Shared
-@inherits DatabaseComponentBase
+@inherits AuditContentBase<DirectoryEntryAuditLog>
 <TimeframeSelector OnTimeframeChanged="TimeframeChanged" />
 
 <MudDataGrid Height="600px"
@@ -68,24 +68,10 @@
     </Columns>
 </MudDataGrid>
 @code {
-    private List<DirectoryEntryAuditLog> auditEntries = new();
-    private DateTime? StartDate = DateTime.Today.AddDays(-7);
-    private DateTime? EndDate = DateTime.Today;
-
-    protected override async Task OnInitializedAsync()
+    protected override async Task FetchData()
     {
-        await base.OnInitializedAsync();
-        await GetAttempts(StartDate, EndDate);
-    }
-    private async Task TimeframeChanged((DateTime? start, DateTime? end) dates)
-    {
- 
-        await GetAttempts(dates.start, dates.end);
-    }
-    private async Task GetAttempts(DateTime? startDate, DateTime? endDate)
-    {
-        if (startDate == null || endDate == null) return;
-        auditEntries = await Context.DirectoryEntryAuditLogs.Where(e => e.Timestamp >= startDate && e.Timestamp < endDate.Value.AddDays(1)).OrderByDescending(e => e.Timestamp).ToListAsync();
-        await StateHasChangedAsync();
+        if (StartDate == null || EndDate == null) return;
+        auditEntries = await Context.DirectoryEntryAuditLogs.Where(e => e.Timestamp >= StartDate && e.Timestamp < EndDate.Value.AddDays(1)).OrderByDescending(e => e.Timestamp).ToListAsync();
+        await InvokeAsync(StateHasChanged);
     }
 }

--- a/BLAZAMGui/UI/Settings/Audit/SystemAuditContent.razor
+++ b/BLAZAMGui/UI/Settings/Audit/SystemAuditContent.razor
@@ -1,4 +1,5 @@
-﻿@inherits DatabaseComponentBase
+﻿@using BLAZAM.Database.Models.Audit
+@inherits AuditContentBase<SystemAuditLog>
 
 @if (ApplicationInfo.InDemoMode && CurrentUser.Username == "Demo")
 {
@@ -12,7 +13,7 @@ else
                  ColumnResizeMode="ResizeMode.Container"
                  FixedHeader=true
                  Hideable=true
-                 Items="@systemAuditEntries.OrderByDescending(ae => ae.Timestamp)"
+                 Items="@auditEntries.OrderByDescending(ae => ae.Timestamp)"
                  Filterable="false"
                  SortMode="@SortMode.Multiple"
                  Groupable="false">
@@ -37,24 +38,10 @@ else
 
 
 @code {
-    private List<SystemAuditLog> systemAuditEntries = new();
-    private DateTime? StartDate = DateTime.Today.AddDays(-7);
-    private DateTime? EndDate = DateTime.Today;
-
-    protected override async Task OnInitializedAsync()
+    protected override async Task FetchData()
     {
-        await base.OnInitializedAsync();
-        await GetAttempts(StartDate, EndDate);
-    }
-    private async Task TimeframeChanged((DateTime? start, DateTime? end) dates)
-    {
-
-        await GetAttempts(dates.start, dates.end);
-    }
-    private async Task GetAttempts(DateTime? startDate, DateTime? endDate)
-    {
-        if (startDate == null || endDate == null) return;
-        systemAuditEntries = await Context.SystemAuditLog.Where(e => e.Timestamp >= startDate && e.Timestamp < endDate.Value.AddDays(1)).OrderByDescending(e => e.Timestamp).ToListAsync();
-        await StateHasChangedAsync();
+        if (StartDate == null || EndDate == null) return;
+        auditEntries = await Context.SystemAuditLog.Where(e => e.Timestamp >= StartDate && e.Timestamp < EndDate.Value.AddDays(1)).OrderByDescending(e => e.Timestamp).ToListAsync();
+        await InvokeAsync(StateHasChanged);
     }
 }

--- a/BLAZAMGui/UI/Settings/Audit/WebHookAuditContent.razor
+++ b/BLAZAMGui/UI/Settings/Audit/WebHookAuditContent.razor
@@ -1,10 +1,11 @@
+@using BLAZAM.Database.Models.Audit
 @using BLAZAM.Gui.UI.Shared
- @inherits DatabaseComponentBase
+@inherits AuditContentBase<WebHookAttempt>
 <TimeframeSelector OnTimeframeChanged="TimeframeChanged" />
 <MudDataGrid ColumnResizeMode="ResizeMode.Container"
              FixedHeader=true
              Hideable=true
-             Items="@_attempts"
+             Items="@auditEntries"
              Filterable="true"
              SortMode="@SortMode.Multiple"
              Groupable="false">
@@ -62,26 +63,12 @@
 </MudDataGrid>
 
 @code {
-    private DateTime? StartDate = DateTime.Today.AddDays(-7);
-    private DateTime? EndDate = DateTime.Today;
-    private List<WebHookAttempt> _attempts = new();
-    protected override async Task OnInitializedAsync()
+    protected override async Task FetchData()
     {
-        await base.OnInitializedAsync();
-        await GetAttempts(StartDate, EndDate);
-    }
-    private async Task TimeframeChanged((DateTime? start, DateTime? end) dates)
-    {
-        StartDate = dates.start;
-        EndDate = dates.end;
-        await GetAttempts(StartDate, EndDate);
-    }
-    private async Task GetAttempts(DateTime? startDate, DateTime? endDate)
-    {
-        if (startDate == null || endDate == null) return;
+        if (StartDate == null || EndDate == null) return;
 
-        _attempts = await Context.WebHookAttempts.Where(e => e.LastAttemptTimestamp >= startDate && e.LastAttemptTimestamp < endDate.Value.AddDays(1)).OrderByDescending(e=>e.LastAttemptTimestamp).ToListAsync();
-        await StateHasChangedAsync();
+        auditEntries = await Context.WebHookAttempts.Where(e => e.LastAttemptTimestamp >= StartDate && e.LastAttemptTimestamp < EndDate.Value.AddDays(1)).OrderByDescending(e => e.LastAttemptTimestamp).ToListAsync();
+        await InvokeAsync(StateHasChanged);
     }
 }
 


### PR DESCRIPTION
This refactor addresses code duplication across multiple audit-related UI components. By introducing a generic base class, `AuditContentBase<T>`, the common logic for managing search timeframes and triggering database queries is centralized, improving maintainability. Each specific audit view now focuses solely on its unique data fetching query and UI layout.

---
*PR created automatically by Jules for task [3762777763936502326](https://jules.google.com/task/3762777763936502326) started by @jacobsen9026*