### PR TITLE
Fixed missing encryption on SMTP password

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -5,8 +5,8 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
-		<AssemblyVersion>1.5.3</AssemblyVersion>
-		<Version>2026.04.07.0027</Version>
+		<AssemblyVersion>1.5.4</AssemblyVersion>
+		<Version>2026.04.07.2158</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMDatabase/Models/EmailSettings.cs
+++ b/BLAZAMDatabase/Models/EmailSettings.cs
@@ -27,7 +27,10 @@ namespace BLAZAM.Database.Models
         public bool UseSMTPAuth { get; set; } = false;
 
         public string? SMTPUsername { get; set; }
-
+ 
+        /// <summary>
+        /// The password for authentication, in encrypted form.
+        /// </summary>
         public string? SMTPPassword { get; set; }
 
         [Required]
@@ -38,7 +41,7 @@ namespace BLAZAM.Database.Models
         public int SMTPPort { get; set; } = 25;
 
         public bool UseTLS { get; set; } = false;
-
+       
         public bool Valid()
         {
             if (SMTPServer != null

--- a/BLAZAMGui/UI/Settings/EmailSettings.razor
+++ b/BLAZAMGui/UI/Settings/EmailSettings.razor
@@ -188,7 +188,7 @@
     {
         if (newPassword == null || newPassword.IsNullOrEmpty())
         {
-            settings.SMTPPassword = string.Empty;
+            settings.SMTPPassword = null;
             return;
         }
 

--- a/BLAZAMGui/UI/Settings/EmailSettings.razor
+++ b/BLAZAMGui/UI/Settings/EmailSettings.razor
@@ -71,7 +71,9 @@
 
                 <MudTextField Label="@AppLocalization[Lang.SMTP_Password]"
                               For=@(() => settings.SMTPPassword)
-                              @bind-Value="settings.SMTPPassword" />
+                              InputType="InputType.Password"
+                              Value="@settings.SMTPPassword"
+                              ValueChanged="@(async (string val)=>{await SetPassword(val);})" />
 
             </SettingsField>
         }
@@ -162,7 +164,7 @@
                     emailPreview = EmailService.BuildMessage<TestEmailMessage>("BLAZAM Test Email", "to@test.com").HtmlBody;
                 await StateHasChangedAsync();
             });
-      
+
         LoadingData = false;
         await StateHasChangedAsync();
     }
@@ -181,6 +183,18 @@
         }
         LoadingData = false;
     }
+
+    private async Task SetPassword(string? newPassword)
+    {
+        if (newPassword == null || newPassword.IsNullOrEmpty())
+        {
+            settings.SMTPPassword = string.Empty;
+            return;
+        }
+
+        settings.SMTPPassword = await newPassword.EncryptAsync();
+    }
+
     protected override async Task Save()
     {
         if (settings.Id == 0 && Context != null)

--- a/BLAZAMServices/Background/EmailService.cs
+++ b/BLAZAMServices/Background/EmailService.cs
@@ -152,7 +152,7 @@ namespace BLAZAM.Services.Background
                     if (settings.UseSMTPAuth)
                     {
                         // Authenticate with the server
-                        await client.AuthenticateAsync(settings.SMTPUsername, settings.SMTPPassword);
+                        await client.AuthenticateAsync(settings.SMTPUsername, settings.SMTPPassword?.Decrypt());
                     }
 
                     return client;


### PR DESCRIPTION
- Store SMTP password in encrypted form in EmailSettings
- Decrypt password only when authenticating with SMTP server
- Update UI to mask password input and encrypt on change
- Refactor password binding to use async handler
- Increment project and build version numbers