### PR TITLE
Update NuGet packages

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.4</AssemblyVersion>
-		<Version>2026.04.07.2158</Version>
+		<Version>2026.04.07.2216</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.25" />
     <PackageVersion Include="Microsoft.AspNetCore.ResponseCompression" Version="2.3.9" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.25" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.25" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.25" />
@@ -35,11 +35,11 @@
     <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.58.0" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.14" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="MudBlazor" Version="9.1.0" />
+    <PackageVersion Include="MudBlazor" Version="9.2.0" />
     <PackageVersion Include="MudBlazor.Markdown" Version="9.0.0" />
     <PackageVersion Include="MudBlazor.ThemeManager" Version="3.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />


### PR DESCRIPTION
Upgraded Microsoft.CodeAnalysis.CSharp to 5.3.0, Microsoft.NET.Test.Sdk to 18.4.0, and MudBlazor to 9.2.0. Also incremented the application version in BLAZAM.csproj to 2026.04.07.2216.