### PR TITLE
Fix for Global Rule Settings table never being created

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.4</AssemblyVersion>
-		<Version>2026.04.10.1459</Version>
+		<Version>2026.04.11.1713</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAM/Pages/_Layout.cshtml
+++ b/BLAZAM/Pages/_Layout.cshtml
@@ -51,7 +51,7 @@
         <a class="dismiss">🗙</a>
     </div>
     <script src="_framework/blazor.server.js"></script>
-    @if (DatabaseCache.ApplicationSettings?.SendDeveloperAnalytics == true)
+    @if (DatabaseCache.ApplicationSettings?.SendDeveloperAnalytics == true || !ApplicationInfo.InstallationCompleted)
     {
         if (!ApplicationInfo.InDemoMode && !ApplicationInfo.InDebugMode && !Debugger.IsAttached)
         {

--- a/BLAZAMActiveDirectory/Adapters/DirectoryEntryAdapter.cs
+++ b/BLAZAMActiveDirectory/Adapters/DirectoryEntryAdapter.cs
@@ -434,9 +434,13 @@ namespace BLAZAM.ActiveDirectory.Adapters
         {
             get
             {
-                var bytes = GetAttribute<byte[]>("objectGUID");
-                var guid = bytes.ToGuid();
-                return guid;
+                var str = GetStringAttribute("objectGUID");
+                if (System.Guid.TryParse(str, out var guid))
+                {
+                    return guid;
+                }
+
+                return null;
             }
             set
             {

--- a/BLAZAMActiveDirectory/Adapters/DirectoryEntryAdapter.cs
+++ b/BLAZAMActiveDirectory/Adapters/DirectoryEntryAdapter.cs
@@ -442,10 +442,6 @@ namespace BLAZAM.ActiveDirectory.Adapters
 
                 return null;
             }
-            set
-            {
-                SetAttribute("objectGUID", value?.ToByteArray());
-            }
 
         }
 

--- a/BLAZAMActiveDirectory/Interfaces/IDirectoryEntryAdapter.cs
+++ b/BLAZAMActiveDirectory/Interfaces/IDirectoryEntryAdapter.cs
@@ -284,7 +284,7 @@ namespace BLAZAM.ActiveDirectory.Interfaces
         /// </summary>
         [JsonIgnore]
         AppEvent OnChangesDiscarded { get; set; }
-        Guid? Guid { get; set; }
+        Guid? Guid { get; }
         IADUser? Manager { get; set; }
         IEnumerable<IDirectoryEntryAdapter>? CachedChildren { get; set; }
 


### PR DESCRIPTION
Changed DirectoryEntryAdapter to retrieve objectGUID as a string and parse it to Guid, instead of converting from a byte array. Returns null if parsing fails.