### PR TITLE
Update NuGet packages

### DIFF
--- a/BLAZAM.Gui.Tests/BLAZAM.Gui.Tests.csproj
+++ b/BLAZAM.Gui.Tests/BLAZAM.Gui.Tests.csproj
@@ -11,7 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="bunit" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />

--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.5</AssemblyVersion>
-		<Version>2026.04.19.2034</Version>
+		<Version>2026.04.20.0233</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,41 +7,41 @@
     <PackageVersion Include="bunit" Version="2.7.2" />
     <PackageVersion Include="bunit.web" Version="1.40.0" />
     <PackageVersion Include="Cassia" Version="2.0.0.60" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
-    <PackageVersion Include="coverlet.msbuild" Version="8.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="coverlet.msbuild" Version="10.0.0" />
     <PackageVersion Include="DuoUniversal" Version="1.3.1" />
     <PackageVersion Include="Google.Apis" Version="1.73.0" />
     <PackageVersion Include="Google.Apis.Admin.Directory.directory_v1" Version="1.73.0.4075" />
     <PackageVersion Include="Google.Apis.Auth" Version="1.73.0" />
     <PackageVersion Include="GoogleAuthenticator" Version="3.2.0" />
-    <PackageVersion Include="MailKit" Version="4.15.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.25" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="8.0.25" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.25" />
+    <PackageVersion Include="MailKit" Version="4.16.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.26" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="8.0.26" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.26" />
     <PackageVersion Include="Microsoft.AspNetCore.ResponseCompression" Version="2.3.9" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.25" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.25" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.25" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.25" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.25" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.25" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.25" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.26" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.26" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.26" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.26" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.26" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.26" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.26" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.58.0" />
+    <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.59.0" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.14" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="MudBlazor" Version="9.2.0" />
+    <PackageVersion Include="MudBlazor" Version="9.3.0" />
     <PackageVersion Include="MudBlazor.Markdown" Version="9.0.0" />
     <PackageVersion Include="MudBlazor.ThemeManager" Version="3.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
@@ -61,14 +61,14 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
     <PackageVersion Include="System.Data.SQLite" Version="2.0.3" />
-    <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.5" />
-    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.5" />
-    <PackageVersion Include="System.DirectoryServices" Version="10.0.5" />
-    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="10.0.5" />
-    <PackageVersion Include="System.DirectoryServices.Protocols" Version="10.0.5" />
-    <PackageVersion Include="System.Drawing.Common" Version="10.0.5" />
-    <PackageVersion Include="System.Management" Version="10.0.5" />
-    <PackageVersion Include="System.Security.Permissions" Version="10.0.5" />
+    <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.6" />
+    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.6" />
+    <PackageVersion Include="System.DirectoryServices" Version="10.0.6" />
+    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="10.0.6" />
+    <PackageVersion Include="System.DirectoryServices.Protocols" Version="10.0.6" />
+    <PackageVersion Include="System.Drawing.Common" Version="10.0.6" />
+    <PackageVersion Include="System.Management" Version="10.0.6" />
+    <PackageVersion Include="System.Security.Permissions" Version="10.0.6" />
     <PackageVersion Include="TaskScheduler" Version="2.12.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
Upgraded multiple NuGet dependencies to latest patch versions, including coverlet.collector, MailKit, Microsoft.AspNetCore, Microsoft.EntityFrameworkCore, Microsoft.Extensions, Microsoft.Playwright.NUnit, MudBlazor, and System.* packages. Enhanced coverlet.collector reference in BLAZAM.Gui.Tests.csproj for better dependency management. Bumped project version in BLAZAM.csproj to 2026.04.20.0233.