### PR TITLE
Fix templates not being able to be saved

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.5</AssemblyVersion>
-		<Version>2026.04.20.1336</Version>
+		<Version>2026.04.20.1649</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.5</AssemblyVersion>
-		<Version>2026.04.20.1649</Version>
+		<Version>2026.04.20.1704</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMDatabase/Helpers/DatabaseHelpers.cs
+++ b/BLAZAMDatabase/Helpers/DatabaseHelpers.cs
@@ -498,5 +498,26 @@ namespace BLAZAM.Helpers
                 entity.Navigation(e => e.ChatMessage).AutoInclude();
             });
         }
+
+        public static async Task<DirectoryTemplate?> LoadTemplateWithParents(this DbSet<DirectoryTemplate> dbSet,int? templateId)
+        {
+           
+            if (templateId == null)
+            {
+                return null;
+            }
+            var template = await dbSet.Include(t => t.ParentTemplate).FirstOrDefaultAsync(t => t.Id.Equals(templateId));
+            if (template?.ParentTemplate != null)
+            {
+                var parentTemplate = await dbSet.Include(t => t.ParentTemplate).FirstOrDefaultAsync(t => t.Id.Equals(template.ParentTemplate.Id));
+                if (parentTemplate != null && parentTemplate.ParentTemplate != null)
+                {
+                    parentTemplate.ParentTemplate = await dbSet.LoadTemplateWithParents(parentTemplate.ParentTemplate.Id);
+                }
+                template.ParentTemplate = parentTemplate;
+            }
+            return template;
+        
+    }
     }
 }

--- a/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor
+++ b/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor
@@ -1,26 +1,26 @@
 ﻿@inherits ValidatedForm
 @attribute [Authorize]
-@if (DirectoryTemplate != null)
+@if (_workingTemplate != null)
 {
-    <CascadingValue Value="DirectoryTemplate">
+    <CascadingValue Value="_workingTemplate">
         <MudForm @ref=Form IsValidChanged="@((val)=>{SaveDisabled = !val;})">
-            <CascadingValue Value="DirectoryTemplate">
+            <CascadingValue Value="_workingTemplate">
                 <MudStack>
-                    <MudText Class="mt-5" Typo="Typo.h6">@AppLocalization[Lang.Current_Template]: @originalTemplate.Name</MudText>
+                    <MudText Class="mt-5" Typo="Typo.h6">@AppLocalization[Lang.Current_Template]: @_workingTemplate.Name</MudText>
                         <MudSelectList T="DirectoryTemplate"
                                        HelperText="@(dropdownTemplates.IsNullOrEmpty()?"There are no other templates":null)"
                                        Disabled=@(dropdownTemplates.IsNullOrEmpty())
                                        Label=@AppLocalization[Lang.Parent_Template]
                                        Options="@dropdownTemplates.OrderBy(t=>t.Name)"
-                                       Value="@DirectoryTemplate.ParentTemplate"
+                                       Value="@_workingTemplate.ParentTemplate"
                                        ValueChanged="@ParentTemplateChanged" />
 
                         <MudTextField Label="@AppLocalization["Template Id"]"
                                       ReadOnly=true
-                                      @bind-Value=DirectoryTemplate.Id />
+                                      @bind-Value=_workingTemplate.Id />
 
                         <MudTextField Label="@AppLocalization[Lang.Template_Name]"
-                                      @bind-Value=DirectoryTemplate.Name />
+                                      @bind-Value=_workingTemplate.Name />
 
 
                         <MudSelectList T="string"
@@ -29,13 +29,13 @@
                                        AdornmentColor="@Color.Success"
                                        OnAdornmentClick="@(()=>{_=categoryModal?.ShowAsync();})"
                                        Options="@(categories.Count>0?categories:new List<string>())"
-                                       ValueChanged="@((value)=>{DirectoryTemplate.Category=value;})"
-                                       @bind-Text=DirectoryTemplate.Category
+                                       ValueChanged="@((value)=>{_workingTemplate.Category=value;})"
+                                       @bind-Text=_workingTemplate.Category
                                        Label="@AppLocalization[Lang.Template_Category]" />
                         <AppModal @ref=categoryModal Title=@AppLocalization[Lang.Add_Category]>
                             <AddTemplateCategoryModalContent Categories="@categories"
                                                              CategoryAdded="@(async(newCategory)=>{
-                                    DirectoryTemplate.Category=newCategory;
+                                    _workingTemplate.Category=newCategory;
                                     categories.Add(newCategory);
                                     await StateHasChangedAsync();
                                                                                             })" />
@@ -43,7 +43,7 @@
                         <MudSwitch Label="@AppLocalization[Lang.Visible]"
                                    UncheckedColor="Color.Warning"
                                    Color="Color.Success"
-                                   @bind-Value=@DirectoryTemplate.Visible />
+                                   @bind-Value=@_workingTemplate.Visible />
                         <MudExpansionPanel Text=@AppLocalization[Lang.Variables]>
                             <MudStack>
                                 <MudText Typo="Typo.h6">
@@ -75,11 +75,11 @@
                                         <MudTextField Required="true"
                                                       RequiredError=@AppLocalization["This field is required"]
                                                       Label=@AppLocalization[Lang.Username_Format]
-                                                      @bind-Value=DirectoryTemplate.EffectiveUsernameFormula />
+                                                      @bind-Value=_workingTemplate.EffectiveUsernameFormula />
                                     </TemplateOverride>
-                                    @if (DirectoryTemplate.ParentTemplate != null && DirectoryTemplate.ParentTemplate.EffectiveUsernameFormula != DirectoryTemplate.EffectiveUsernameFormula)
+                                    @if (_workingTemplate.ParentTemplate != null && _workingTemplate.ParentTemplate.EffectiveUsernameFormula != _workingTemplate.EffectiveUsernameFormula)
                                     {
-                                        <RevertTemplateValueButton OnClick=@(()=>{ DirectoryTemplate.UsernameFormula=null;}) />
+                                        <RevertTemplateValueButton OnClick=@(()=>{ _workingTemplate.UsernameFormula=null;}) />
                                     }
                                 </MudStack>
                                 <MudStack Row=true>
@@ -87,11 +87,11 @@
                                         <MudTextField Required="true"
                                                       RequiredError=@AppLocalization["This field is required"]
                                                       Label=@AppLocalization[Lang.Display_Name_Format]
-                                                      @bind-Value=DirectoryTemplate.EffectiveDisplayNameFormula />
+                                                      @bind-Value=_workingTemplate.EffectiveDisplayNameFormula />
                                     </TemplateOverride>
-                                    @if (DirectoryTemplate.ParentTemplate != null && DirectoryTemplate.ParentTemplate.EffectiveDisplayNameFormula != DirectoryTemplate.EffectiveDisplayNameFormula)
+                                    @if (_workingTemplate.ParentTemplate != null && _workingTemplate.ParentTemplate.EffectiveDisplayNameFormula != _workingTemplate.EffectiveDisplayNameFormula)
                                     {
-                                        <RevertTemplateValueButton OnClick=@(()=>{ DirectoryTemplate.DisplayNameFormula=null;}) />
+                                        <RevertTemplateValueButton OnClick=@(()=>{ _workingTemplate.DisplayNameFormula=null;}) />
                                     }
                                 </MudStack>
 
@@ -106,11 +106,11 @@
                                                   RequiredError=@AppLocalization["This field is required"]
                                                   FullWidth=true
                                                   Label=@AppLocalization[Lang.Password]
-                                                  @bind-Value=DirectoryTemplate.EffectivePasswordFormula />
+                                                  @bind-Value=_workingTemplate.EffectivePasswordFormula />
                                 </TemplateOverride>
-                                @if (DirectoryTemplate.ParentTemplate != null && DirectoryTemplate.ParentTemplate.EffectivePasswordFormula != DirectoryTemplate.EffectivePasswordFormula)
+                                @if (_workingTemplate.ParentTemplate != null && _workingTemplate.ParentTemplate.EffectivePasswordFormula != _workingTemplate.EffectivePasswordFormula)
                                 {
-                                    <RevertTemplateValueButton OnClick=@(()=>{ DirectoryTemplate.PasswordFormula=null;}) />
+                                    <RevertTemplateValueButton OnClick=@(()=>{ _workingTemplate.PasswordFormula=null;}) />
                                 }
                             </MudStack>
                             <MudStack Row=true>
@@ -119,11 +119,11 @@
                                     <MudSwitch Label=@AppLocalization[Lang.Allow_Username_Override]
                                                UncheckedColor="Color.Error"
                                                Color="Color.Success"
-                                               @bind-Value=DirectoryTemplate.EffectiveAllowUsernameOverride />
+                                               @bind-Value=_workingTemplate.EffectiveAllowUsernameOverride />
                                 </TemplateOverride>
-                                @if (DirectoryTemplate.ParentTemplate != null && DirectoryTemplate.ParentTemplate.EffectiveAllowUsernameOverride != DirectoryTemplate.EffectiveAllowUsernameOverride)
+                                @if (_workingTemplate.ParentTemplate != null && _workingTemplate.ParentTemplate.EffectiveAllowUsernameOverride != _workingTemplate.EffectiveAllowUsernameOverride)
                                 {
-                                    <RevertTemplateValueButton OnClick=@(()=>{ DirectoryTemplate.AllowUsernameOverride=null;}) />
+                                    <RevertTemplateValueButton OnClick=@(()=>{ _workingTemplate.AllowUsernameOverride=null;}) />
                                 }
                             </MudStack>
                             <MudStack Row=true>
@@ -132,11 +132,11 @@
                                     <MudSwitch Label=@AppLocalization[Lang.Require_Password_Change]
                                                UncheckedColor="Color.Warning"
                                                Color="Color.Success"
-                                               @bind-Value=DirectoryTemplate.EffectiveRequirePasswordChange />
+                                               @bind-Value=_workingTemplate.EffectiveRequirePasswordChange />
                                 </TemplateOverride>
-                                @if (DirectoryTemplate.ParentTemplate != null && DirectoryTemplate.ParentTemplate.EffectiveRequirePasswordChange != DirectoryTemplate.EffectiveRequirePasswordChange)
+                                @if (_workingTemplate.ParentTemplate != null && _workingTemplate.ParentTemplate.EffectiveRequirePasswordChange != _workingTemplate.EffectiveRequirePasswordChange)
                                 {
-                                    <RevertTemplateValueButton OnClick=@(()=>{ DirectoryTemplate.RequirePasswordChange=null;}) />
+                                    <RevertTemplateValueButton OnClick=@(()=>{ _workingTemplate.RequirePasswordChange=null;}) />
                                 }
                             </MudStack>
                             <TemplateOverride Class="mud-width-full"
@@ -146,13 +146,13 @@
                                 <MudSwitch Label="@AppLocalization[Lang.Send_Welcome_Email]"
                                            UncheckedColor="Color.Error"
                                            Color="Color.Success"
-                                           @bind-Value=@DirectoryTemplate.EffectiveSendWelcomeEmail />
-                                @if (DirectoryTemplate.ParentTemplate != null && DirectoryTemplate.ParentTemplate.EffectiveSendWelcomeEmail != DirectoryTemplate.EffectiveSendWelcomeEmail)
+                                           @bind-Value=@_workingTemplate.EffectiveSendWelcomeEmail />
+                                @if (_workingTemplate.ParentTemplate != null && _workingTemplate.ParentTemplate.EffectiveSendWelcomeEmail != _workingTemplate.EffectiveSendWelcomeEmail)
                                 {
-                                    <RevertTemplateValueButton OnClick=@(()=>{ DirectoryTemplate.SendWelcomeEmail=null;}) />
+                                    <RevertTemplateValueButton OnClick=@(()=>{ _workingTemplate.SendWelcomeEmail=null;}) />
                                 }
-                                @if (DirectoryTemplate.EffectiveSendWelcomeEmail == true && DirectoryTemplate.EffectiveAskForAlternateEmail != true &&
-                            (DirectoryTemplate.EffectiveFieldValues.Any(fv => fv.Field.Id == ActiveDirectoryFields.Mail.Id) && !DirectoryTemplate.EffectiveFieldValues.First(fv => fv.Field.Id == ActiveDirectoryFields.Mail.Id).Value.IsNullOrEmpty()))
+                                @if (_workingTemplate.EffectiveSendWelcomeEmail == true && _workingTemplate.EffectiveAskForAlternateEmail != true &&
+                            (_workingTemplate.EffectiveFieldValues.Any(fv => fv.Field.Id == ActiveDirectoryFields.Mail.Id) && !_workingTemplate.EffectiveFieldValues.First(fv => fv.Field.Id == ActiveDirectoryFields.Mail.Id).Value.IsNullOrEmpty()))
                                 {
                                     <MudAlert Severity="Severity.Warning">
                                         @AppLocalization["Send Email is true while ask for email is false, you have also set an email value. Welcome Emails will be sent to the email generated by Blazam! This is likely unintended behavior!"]
@@ -167,11 +167,11 @@
                                 <MudSwitch Label="@AppLocalization[Lang.Ask_For_Alternate_Email]"
                                            UncheckedColor="Color.Error"
                                            Color="Color.Success"
-                                           @bind-Value=@DirectoryTemplate.EffectiveAskForAlternateEmail />
+                                           @bind-Value=@_workingTemplate.EffectiveAskForAlternateEmail />
                             </TemplateOverride>
-                            @if (DirectoryTemplate.ParentTemplate != null && DirectoryTemplate.ParentTemplate.EffectiveAskForAlternateEmail != DirectoryTemplate.EffectiveAskForAlternateEmail)
+                            @if (_workingTemplate.ParentTemplate != null && _workingTemplate.ParentTemplate.EffectiveAskForAlternateEmail != _workingTemplate.EffectiveAskForAlternateEmail)
                             {
-                                <RevertTemplateValueButton OnClick=@(()=>{ DirectoryTemplate.AskForAlternateEmail=null;}) />
+                                <RevertTemplateValueButton OnClick=@(()=>{ _workingTemplate.AskForAlternateEmail=null;}) />
                             }
                             <MudExpansionPanel Text="@AppLocalization[Lang.Formula_sim]">
                                 <MudGrid>
@@ -204,13 +204,13 @@
                                             }
                                             <MudTextField T="string"
                                                           Label="@AppLocalization[Lang.Username]"
-                                                          Value="@(DirectoryTemplate.EffectiveUsernameFormula.IsNullOrEmpty()==false?DirectoryTemplate.ReplaceVariables(DirectoryTemplate.EffectiveUsernameFormula,testName):null)" />
+                                                          Value="@(_workingTemplate.EffectiveUsernameFormula.IsNullOrEmpty()==false?_workingTemplate.ReplaceVariables(_workingTemplate.EffectiveUsernameFormula,testName):null)" />
                                             <MudTextField T="string"
                                                           Label="@AppLocalization[Lang.Display_Name]"
-                                                          Value="@(DirectoryTemplate.EffectiveDisplayNameFormula.IsNullOrEmpty()==false?DirectoryTemplate.ReplaceVariables(DirectoryTemplate.EffectiveDisplayNameFormula,testName):null)" />
+                                                          Value="@(_workingTemplate.EffectiveDisplayNameFormula.IsNullOrEmpty()==false?_workingTemplate.ReplaceVariables(_workingTemplate.EffectiveDisplayNameFormula,testName):null)" />
                                             <MudTextField T="string"
                                                           Label="@AppLocalization[Lang.Password]"
-                                                          Value="@(DirectoryTemplate.EffectivePasswordFormula.IsNullOrEmpty()==false?DirectoryTemplate.ReplaceVariables(DirectoryTemplate.EffectivePasswordFormula,testName):null)" />
+                                                          Value="@(_workingTemplate.EffectivePasswordFormula.IsNullOrEmpty()==false?_workingTemplate.ReplaceVariables(_workingTemplate.EffectivePasswordFormula,testName):null)" />
                                         </MudStack>
                                     </MudItem>
                                 </MudGrid>
@@ -255,9 +255,9 @@
                                    field.FieldName != ActiveDirectoryFields.DistinguishedName.FieldName &&
                                    field.FieldName != ActiveDirectoryFields.MemberOf.FieldName &&
                                    field.FieldName != ActiveDirectoryFields.ObjectSID.FieldName &&
-                                   !DirectoryTemplate.EffectiveFieldValues.Any(f => f.Field?.Equals(field) == true) &&
-                                   !DirectoryTemplate.EffectiveFieldValues.Any(f => f.CustomField?.Equals(field) == true) &&
-                                   field.IsFieldAppropriateForObject(DirectoryTemplate.ObjectType))
+                                   !_workingTemplate.EffectiveFieldValues.Any(f => f.Field?.Equals(field) == true) &&
+                                   !_workingTemplate.EffectiveFieldValues.Any(f => f.CustomField?.Equals(field) == true) &&
+                                   field.IsFieldAppropriateForObject(_workingTemplate.ObjectType))
                                         {
                                             <MudButton Class=" my-0" OnClick=@(() => { AddField(field);})>
                                                 <MudText Color="Color.Tertiary">@field.DisplayName</MudText>
@@ -273,7 +273,7 @@
 
 
                             <MudStack Class="d-flex justify-center align-center mud-height-full">
-                                <MudDataGrid Items="@DirectoryTemplate.EffectiveFieldValues.Where(fv=>fv.DeletedAt==null).OrderBy(fv => fv.FieldDisplayName)"
+                                <MudDataGrid Items="@_workingTemplate.EffectiveFieldValues.Where(fv=>fv.DeletedAt==null).OrderBy(fv => fv.FieldDisplayName)"
                                              Dense=true
                                              Striped=true
                                              Bordered=true
@@ -328,14 +328,14 @@
                                             </TemplateColumn>
                                             <TemplateColumn>
                                                 <CellTemplate Context="cellContext">
-                                                    @if (DirectoryTemplate.IsValueOverriden(cellContext.Item))
+                                                    @if (_workingTemplate.IsValueOverriden(cellContext.Item))
                                                 {
                                                     <RevertTemplateValueButton OnClick=@(async()=>{await RemoveField(cellContext.Item);}) />
                                                 }
                                                 else
                                                 {
                                                     <AppTooltip Text="@AppLocalization[Lang.Remove_field]">
-                                                        <AppCloseButton Disabled=@(!DirectoryTemplate.FieldValues.Contains(cellContext.Item))
+                                                        <AppCloseButton Disabled=@(!_workingTemplate.FieldValues.Contains(cellContext.Item))
                                                                         Tooltip=@AppLocalization[Lang.Remove]
                                                                         OnClick=@(async()=>{await RemoveField(cellContext.Item);}) />
                                                     </AppTooltip>
@@ -355,7 +355,7 @@
                     <ViewSection Title=@AppLocalization[Lang.OU]>
                         @if (SelectedOU != null)
                         {
-                            var ouTemplateSource = GetParentOfValue(DirectoryTemplate.EffectiveParentOU, template => template.ParentOU);
+                            var ouTemplateSource = GetParentOfValue(_workingTemplate.EffectiveParentOU, template => template.ParentOU);
                             <MudText Class="mud-width-full" Align="Align.Center">
                                 <MudStack>
                                     <MudText Align="Align.Center">
@@ -372,11 +372,11 @@
                                     {
                                             <ADTreeView ShowAllEntries=false
                                                 SelectedEntry=@SelectedOU
-                                                SelectedEntryChanged="@((ou)=>{SelectedOU=ou as IADOrganizationalUnit; if(DirectoryTemplate.EffectiveParentOU!=ou.DN)DirectoryTemplate.ParentOU = ou.DN;})"
+                                                SelectedEntryChanged="@((ou)=>{SelectedOU=ou as IADOrganizationalUnit; if(_workingTemplate.EffectiveParentOU!=ou.DN)_workingTemplate.ParentOU = ou.DN;})"
                                                 StartingSelectedOU=@SelectedOU />
-                                            @if (!DirectoryTemplate.ParentOU.IsNullOrEmpty() && DirectoryTemplate.ParentTemplateId != null && !DirectoryTemplate.ParentOU.IsNullOrEmpty())
+                                            @if (!_workingTemplate.ParentOU.IsNullOrEmpty() && _workingTemplate.ParentTemplateId != null && !_workingTemplate.ParentOU.IsNullOrEmpty())
                                             {
-                                                <RevertTemplateValueButton OnClick=@(async()=>{DirectoryTemplate.ParentOU=null;await LoadData();}) />
+                                                <RevertTemplateValueButton OnClick=@(async()=>{_workingTemplate.ParentOU=null;await LoadData();}) />
 
                                             }
                                     }
@@ -391,7 +391,7 @@
 
                         <MudStack>
 
-                            @foreach (var group in DirectoryTemplate.EffectiveAssignedGroupSids)
+                            @foreach (var group in _workingTemplate.EffectiveAssignedGroupSids)
                             {
 
                                 //TODO Find a way to identify a single group sid's source template
@@ -424,7 +424,7 @@
 
                 @{
                     string buttonText = "";
-                    @if (DirectoryTemplate.Id == 0)
+                    @if (_workingTemplate.Id == 0)
                     {
                         buttonText = "Add this template";
                     }
@@ -435,7 +435,7 @@
                 }
                 <MudStack Row=true>
 
-                    @if (DirectoryTemplate.Id == 0)
+                    @if (_workingTemplate.Id == 0)
                     {
                         <MudButton Color="Color.Warning"
                                    OnClick="@CancelNewTemplate">Cancel</MudButton>
@@ -450,7 +450,7 @@
 
                 </CascadingValue>
             </MudForm>
-            @*     @if(DirectoryTemplate.GetChanges(originalTemplate).Count>0){
+            @*     @if(_workingTemplate.GetChanges(originalTemplate).Count>0){
     <UnsavedChangesPrompt SaveChanges="SaveChanges" DiscardChanges="DiscardChanges"/>
     } *@
         </CascadingValue>

--- a/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor.cs
+++ b/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor.cs
@@ -58,7 +58,7 @@ namespace BLAZAM.Gui.UI.Settings.Templates
 
         private List<DirectoryTemplate> dropdownTemplates = [];
         private DirectoryTemplate _template;
-        private DirectoryTemplate? _workingTemplate;
+        private DirectoryTemplate _workingTemplate = new();
 
         private DirectoryTemplate usernameFromTemplate;
         private DirectoryTemplate displayNameFromTemplate;
@@ -237,7 +237,7 @@ namespace BLAZAM.Gui.UI.Settings.Templates
                 while (templateCursor.ParentTemplate != null)
                 {
                     templateCursor = templateCursor.ParentTemplate;
-                    if (templateCursor.Equals(DirectoryTemplate))
+                    if (templateCursor.Id.Equals(_workingTemplate.Id))
                     {
                         SnackBarService.Warning("Circular inheritance detected!");
                         return;
@@ -396,7 +396,7 @@ namespace BLAZAM.Gui.UI.Settings.Templates
             }
             catch (SqlException ex)
             {
-                Loggers.DatabaseLogger.Error(ex, "Error attempting to save creation template {@Template}", DirectoryTemplate.Name);
+                Loggers.DatabaseLogger.Error(ex, "Error attempting to save creation template {@Template}", _workingTemplate.Name);
             }
         }
 

--- a/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor.cs
+++ b/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor.cs
@@ -11,7 +11,6 @@ namespace BLAZAM.Gui.UI.Settings.Templates
 
         [Parameter]
         public SetSubHeader? Header { get; set; }
-        protected DirectoryTemplate originalTemplate;
 
 
         private AppModal? categoryModal;
@@ -59,6 +58,7 @@ namespace BLAZAM.Gui.UI.Settings.Templates
 
         private List<DirectoryTemplate> dropdownTemplates = [];
         private DirectoryTemplate _template;
+        private DirectoryTemplate? _workingTemplate;
 
         private DirectoryTemplate usernameFromTemplate;
         private DirectoryTemplate displayNameFromTemplate;
@@ -89,7 +89,6 @@ namespace BLAZAM.Gui.UI.Settings.Templates
                 }
 
                 _template = value;
-                originalTemplate = value;
                 SelectedOU = Directory?.OUs.FindOuByDN(value.EffectiveParentOU);
 
                 DirectoryTemplateChanged.InvokeAsync(value);
@@ -139,31 +138,32 @@ namespace BLAZAM.Gui.UI.Settings.Templates
         {
             if (Context != null)
             {
-                usernameFromTemplate = GetParentOfValue<string?>(DirectoryTemplate.EffectiveUsernameFormula, template => template.UsernameFormula);
-                displayNameFromTemplate = GetParentOfValue<string?>(DirectoryTemplate.EffectiveDisplayNameFormula, template => template.DisplayNameFormula);
-                passwordFromTemplateName = GetParentOfValue<string?>(DirectoryTemplate.EffectivePasswordFormula, template => template.PasswordFormula);
-                requirePasswordChangeFromTemplate = GetParentOfValue<bool?>(DirectoryTemplate.EffectiveRequirePasswordChange, template => template.RequirePasswordChange);
-                sendWelcomeEmailFromTemplate = GetParentOfValue<bool?>(DirectoryTemplate.EffectiveSendWelcomeEmail, template => template.SendWelcomeEmail);
-                askForAlternateEmailFromTemplate = GetParentOfValue<bool?>(DirectoryTemplate.EffectiveAskForAlternateEmail, template => template.AskForAlternateEmail); 
+                _workingTemplate = await Context.DirectoryTemplates.LoadTemplateWithParents(DirectoryTemplate?.Id);
+                usernameFromTemplate = GetParentOfValue<string?>(_workingTemplate.EffectiveUsernameFormula, template => template.UsernameFormula);
+                displayNameFromTemplate = GetParentOfValue<string?>(_workingTemplate.EffectiveDisplayNameFormula, template => template.DisplayNameFormula);
+                passwordFromTemplateName = GetParentOfValue<string?>(_workingTemplate.EffectivePasswordFormula, template => template.PasswordFormula);
+                requirePasswordChangeFromTemplate = GetParentOfValue<bool?>(_workingTemplate.EffectiveRequirePasswordChange, template => template.RequirePasswordChange);
+                sendWelcomeEmailFromTemplate = GetParentOfValue<bool?>(_workingTemplate.EffectiveSendWelcomeEmail, template => template.SendWelcomeEmail);
+                askForAlternateEmailFromTemplate = GetParentOfValue<bool?>(_workingTemplate.EffectiveAskForAlternateEmail, template => template.AskForAlternateEmail); 
 
                 fields = await Context.ActiveDirectoryFields.Cast<IActiveDirectoryField>().ToListAsync();
                 fields.AddRange(await Context.CustomActiveDirectoryFields.Where(cf => cf.DeletedAt == null).Cast<IActiveDirectoryField>().ToListAsync());
 
                 using (var dropdownContext = await DbFactory.CreateDbContextAsync())
                 {
-                    dropdownTemplates = await dropdownContext.DirectoryTemplates.Where(t => !t.Equals(DirectoryTemplate) && t.DeletedAt == null).ToListAsync();
+                    dropdownTemplates = await dropdownContext.DirectoryTemplates.Where(t => !t.Equals(_workingTemplate) && t.DeletedAt == null).ToListAsync();
                 }
 
                 await LoadCategories();
 
 
-                if (DirectoryTemplate != null && Context != null && !Context.EntityIsTracked(DirectoryTemplate))
+                if (_workingTemplate != null && Context != null && !Context.EntityIsTracked(_workingTemplate))
                 {
                     await LoadParentOU();
                 }
                 using (var dropdownContext = await DbFactory.CreateDbContextAsync())
                 {
-                    dropdownTemplates = await dropdownContext.DirectoryTemplates.Where(t => !t.Equals(DirectoryTemplate) && t.DeletedAt == null).ToListAsync();
+                    dropdownTemplates = await dropdownContext.DirectoryTemplates.Where(t => !t.Equals(_workingTemplate) && t.DeletedAt == null).ToListAsync();
                 }
 
                 RefreshGroups();
@@ -184,7 +184,7 @@ namespace BLAZAM.Gui.UI.Settings.Templates
         ///  template, otherwise the source template</returns>
         private DirectoryTemplate? GetParentOfValue<T>(T? value, Func<DirectoryTemplate, T?> valueSelector)
         {
-            var templateCursor = DirectoryTemplate;
+            var templateCursor = _workingTemplate;
             var templateValue = valueSelector.Invoke(templateCursor);
             if (!EqualityComparer<T>.Default.Equals(templateValue, default(T)) && templateValue.Equals(value))
             {
@@ -213,9 +213,9 @@ namespace BLAZAM.Gui.UI.Settings.Templates
         }
         private async Task LoadParentOU()
         {
-            if (!DirectoryTemplate.EffectiveParentOU.IsNullOrEmpty())
+            if (!_workingTemplate.EffectiveParentOU.IsNullOrEmpty())
             {
-                SelectedOU = (await Directory.OUs.FindOuByStringAsync(DirectoryTemplate.EffectiveParentOU)).FirstOrDefault();
+                SelectedOU = (await Directory.OUs.FindOuByStringAsync(_workingTemplate.EffectiveParentOU)).FirstOrDefault();
             }
 
             if (SelectedOU == null)
@@ -241,13 +241,13 @@ namespace BLAZAM.Gui.UI.Settings.Templates
                     }
                 }
 
-                DirectoryTemplate.ParentTemplate = parent;
-                DirectoryTemplate.ParentTemplateId = parent.Id;
+                _workingTemplate.ParentTemplate = parent;
+                _workingTemplate.ParentTemplateId = parent.Id;
             }
             else
             {
-                DirectoryTemplate.ParentTemplateId = null;
-                DirectoryTemplate.ParentTemplate = null;
+                _workingTemplate.ParentTemplateId = null;
+                _workingTemplate.ParentTemplate = null;
             }
 
             await LoadParentOU();
@@ -272,9 +272,9 @@ namespace BLAZAM.Gui.UI.Settings.Templates
         protected void RefreshGroups()
         {
             TemplateGroups.Clear();
-            if (DirectoryTemplate != null)
+            if (_workingTemplate != null)
             {
-                foreach (var sid in DirectoryTemplate.AssignedGroupSids)
+                foreach (var sid in _workingTemplate.AssignedGroupSids)
                 {
                     var temp = Directory.Groups.FindGroupBySID(sid.GroupSid);
                     if (temp != null)
@@ -288,12 +288,12 @@ namespace BLAZAM.Gui.UI.Settings.Templates
 
         private DirectoryTemplateFieldValue GetFieldToEdit(DirectoryTemplateFieldValue fieldValue)
         {
-            if (!DirectoryTemplate.FieldValues.Contains(fieldValue))
+            if (!_workingTemplate.FieldValues.Contains(fieldValue))
             {
-                DirectoryTemplate.FieldValues.Add((DirectoryTemplateFieldValue)fieldValue.Clone(Context));
+                _workingTemplate.FieldValues.Add((DirectoryTemplateFieldValue)fieldValue.Clone(Context));
             }
 
-            var fieldToModify = DirectoryTemplate.FieldValues.FirstOrDefault(fv => (fv.Field != null && fv.Field.Equals(fieldValue.Field)) || (fv.CustomField != null && fv.CustomField.Equals(fieldValue.CustomField)));
+            var fieldToModify = _workingTemplate.FieldValues.FirstOrDefault(fv => (fv.Field != null && fv.Field.Equals(fieldValue.Field)) || (fv.CustomField != null && fv.CustomField.Equals(fieldValue.CustomField)));
             return fieldToModify;
         }
 
@@ -318,7 +318,7 @@ namespace BLAZAM.Gui.UI.Settings.Templates
         }
         protected async Task RemoveField(DirectoryTemplateFieldValue field)
         {
-            DirectoryTemplate.FieldValues.Remove(field);
+            _workingTemplate.FieldValues.Remove(field);
             await StateHasChangedAsync();
         }
 
@@ -333,15 +333,15 @@ namespace BLAZAM.Gui.UI.Settings.Templates
                 throw new AppException("Database not available");
             }
 
-            DirectoryTemplate.ParentOU = SelectedOU?.DN;
+            _workingTemplate.ParentOU = SelectedOU?.DN;
 
-            if (DirectoryTemplate.ParentTemplate != null)
+            if (_workingTemplate.ParentTemplate != null)
             {
-                DirectoryTemplate.ParentTemplate = await Context.DirectoryTemplates
-                    .FirstOrDefaultAsync(x => x.Id == DirectoryTemplate.ParentTemplate.Id);
+                _workingTemplate.ParentTemplate = await Context.DirectoryTemplates
+                    .FirstOrDefaultAsync(x => x.Id == _workingTemplate.ParentTemplate.Id);
             }
 
-            if (DirectoryTemplate.Id == 0)
+            if (_workingTemplate.Id == 0)
             {
                 await AddNewTemplate();
             }
@@ -356,12 +356,12 @@ namespace BLAZAM.Gui.UI.Settings.Templates
             try
             {
                 var trackedGroups = new List<DirectoryTemplateGroup>();
-                foreach (var group in DirectoryTemplate.AssignedGroupSids)
+                foreach (var group in _workingTemplate.AssignedGroupSids)
                 {
                     trackedGroups.Add(group.Clone(Context));
                 }
 
-                foreach (var field in DirectoryTemplate.FieldValues)
+                foreach (var field in _workingTemplate.FieldValues)
                 {
                     if (field.Field != null)
                     {
@@ -373,15 +373,15 @@ namespace BLAZAM.Gui.UI.Settings.Templates
                     }
                 }
 
-                DirectoryTemplate.AssignedGroupSids = trackedGroups;
-                await Context.DirectoryTemplates.AddAsync(DirectoryTemplate);
+                _workingTemplate.AssignedGroupSids = trackedGroups;
+                await Context.DirectoryTemplates.AddAsync(_workingTemplate);
                 var result = await Context.SaveChangesAsync();
-                Analytics.DirectoryTemplateCreated(DirectoryTemplate.Name);
+                Analytics.DirectoryTemplateCreated(_workingTemplate.Name);
                 Header?.OnRefreshRequested?.Invoke();
                 if (result > 0)
                 {
-                    SnackBarService.Success(DirectoryTemplate.Name + " was added.");
-                    Nav.NavigateTo($"/templates/{DirectoryTemplate.Id}");
+                    SnackBarService.Success(_workingTemplate.Name + " was added.");
+                    Nav.NavigateTo($"/templates/{_workingTemplate.Id}");
                 }
             }
             catch (DbUpdateException ex)
@@ -399,10 +399,14 @@ namespace BLAZAM.Gui.UI.Settings.Templates
 
         private async Task UpdateExistingTemplate()
         {
+            if (Context.EntityIsTracked(_workingTemplate))
+            {
+                Loggers.SystemLogger.Debug("Directory Template is tracked for updating");
+            }
             var result = await Context.SaveChangesAsync();
             if (result > 0)
             {
-                Analytics.DirectoryTemplateEdited(DirectoryTemplate.Name);
+                Analytics.DirectoryTemplateEdited(_workingTemplate.Name);
                 SnackBarService.Success("Template changes saved");
             }
             else
@@ -420,11 +424,11 @@ namespace BLAZAM.Gui.UI.Settings.Templates
         {
             if (field is ActiveDirectoryField adField)
             {
-                DirectoryTemplate.FieldValues.Add(new DirectoryTemplateFieldValue { Field = adField });
+                _workingTemplate.FieldValues.Add(new DirectoryTemplateFieldValue { Field = adField });
             }
             else if (field is CustomActiveDirectoryField customField)
             {
-                DirectoryTemplate.FieldValues.Add(new DirectoryTemplateFieldValue { CustomField = customField });
+                _workingTemplate.FieldValues.Add(new DirectoryTemplateFieldValue { CustomField = customField });
             }
         }
     }

--- a/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor.cs
+++ b/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor.cs
@@ -119,7 +119,7 @@ namespace BLAZAM.Gui.UI.Settings.Templates
                         };
                     }
 
-                    DirectoryTemplate.AssignedGroupSids.Add(existing);
+                    _workingTemplate?.AssignedGroupSids.Add(existing);
                     SelectedGroup = null;
                 }
 
@@ -138,7 +138,14 @@ namespace BLAZAM.Gui.UI.Settings.Templates
         {
             if (Context != null)
             {
-                _workingTemplate = await Context.DirectoryTemplates.LoadTemplateWithParents(DirectoryTemplate?.Id);
+                if (DirectoryTemplate.Id > 0)
+                {
+                    _workingTemplate = await Context.DirectoryTemplates.LoadTemplateWithParents(DirectoryTemplate?.Id);
+                }
+                else
+                {
+                    _workingTemplate = DirectoryTemplate;
+                }
                 usernameFromTemplate = GetParentOfValue<string?>(_workingTemplate.EffectiveUsernameFormula, template => template.UsernameFormula);
                 displayNameFromTemplate = GetParentOfValue<string?>(_workingTemplate.EffectiveDisplayNameFormula, template => template.DisplayNameFormula);
                 passwordFromTemplateName = GetParentOfValue<string?>(_workingTemplate.EffectivePasswordFormula, template => template.PasswordFormula);
@@ -161,11 +168,7 @@ namespace BLAZAM.Gui.UI.Settings.Templates
                 {
                     await LoadParentOU();
                 }
-                using (var dropdownContext = await DbFactory.CreateDbContextAsync())
-                {
-                    dropdownTemplates = await dropdownContext.DirectoryTemplates.Where(t => !t.Equals(_workingTemplate) && t.DeletedAt == null).ToListAsync();
-                }
-
+                
                 RefreshGroups();
                 await StateHasChangedAsync();
                 if (Form != null)


### PR DESCRIPTION
Introduce LoadTemplateWithParents to recursively load a DirectoryTemplate and its parent chain from the database. Refactor EditDirectoryTemplate.razor and its code-behind to use a new _workingTemplate field for all data binding and logic, replacing direct use of DirectoryTemplate. Update all UI and logic to operate on _workingTemplate, ensuring full parent inheritance is available during editing. Adjust save/add logic and related methods accordingly. Increment version number. This improves reliability and correctness of template inheritance and editing.