### PR TITLE
Sort template category names in category drop down #1410

### DIFF
--- a/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor
+++ b/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor
@@ -8,10 +8,10 @@
                 <MudStack>
                     <MudText Class="mt-5" Typo="Typo.h6">@AppLocalization[Lang.Current_Template]: @_workingTemplate.Name</MudText>
                         <MudSelectList T="DirectoryTemplate"
-                                       HelperText="@(dropdownTemplates.IsNullOrEmpty()?"There are no other templates":null)"
-                                       Disabled=@(dropdownTemplates.IsNullOrEmpty())
+                                       HelperText="@(_dropdownTemplates.IsNullOrEmpty()?"There are no other templates":null)"
+                                       Disabled=@(_dropdownTemplates.IsNullOrEmpty())
                                        Label=@AppLocalization[Lang.Parent_Template]
-                                       Options="@dropdownTemplates.OrderBy(t=>t.Name)"
+                                       Options="@_dropdownTemplates.OrderBy(t=>t.Name)"
                                        Value="@_workingTemplate.ParentTemplate"
                                        ValueChanged="@ParentTemplateChanged" />
 
@@ -27,12 +27,12 @@
                                        Adornment="Adornment.End"
                                        AdornmentIcon="@Icons.Material.Filled.Add"
                                        AdornmentColor="@Color.Success"
-                                       OnAdornmentClick="@(()=>{_=categoryModal?.ShowAsync();})"
+                                       OnAdornmentClick="@(()=>{_=_categoryModal?.ShowAsync();})"
                                        Options="@(categories.Count>0?categories:new List<string>())"
                                        ValueChanged="@((value)=>{_workingTemplate.Category=value;})"
                                        @bind-Text=_workingTemplate.Category
                                        Label="@AppLocalization[Lang.Template_Category]" />
-                        <AppModal @ref=categoryModal Title=@AppLocalization[Lang.Add_Category]>
+                        <AppModal @ref=_categoryModal Title=@AppLocalization[Lang.Add_Category]>
                             <AddTemplateCategoryModalContent Categories="@categories"
                                                              CategoryAdded="@(async(newCategory)=>{
                                     _workingTemplate.Category=newCategory;
@@ -71,7 +71,7 @@
 
                             <MudStack Row=true>
                                 <MudStack Row=true>
-                                    <TemplateOverride SourceTemplate="@usernameFromTemplate">
+                                    <TemplateOverride SourceTemplate="@_usernameFromTemplate">
                                         <MudTextField Required="true"
                                                       RequiredError=@AppLocalization["This field is required"]
                                                       Label=@AppLocalization[Lang.Username_Format]
@@ -83,7 +83,7 @@
                                     }
                                 </MudStack>
                                 <MudStack Row=true>
-                                    <TemplateOverride SourceTemplate="@displayNameFromTemplate">
+                                    <TemplateOverride SourceTemplate="@_displayNameFromTemplate">
                                         <MudTextField Required="true"
                                                       RequiredError=@AppLocalization["This field is required"]
                                                       Label=@AppLocalization[Lang.Display_Name_Format]
@@ -101,7 +101,7 @@
                             </MudStack>
                             <MudStack Row=true>
 
-                                <TemplateOverride Class="mud-width-full" BadgeClass="mud-width-full" SourceTemplate="@passwordFromTemplateName">
+                                <TemplateOverride Class="mud-width-full" BadgeClass="mud-width-full" SourceTemplate="@_passwordFromTemplateName">
                                     <MudTextField Required="true"
                                                   RequiredError=@AppLocalization["This field is required"]
                                                   FullWidth=true
@@ -115,7 +115,7 @@
                             </MudStack>
                             <MudStack Row=true>
 
-                                <TemplateOverride Class="mud-width-full" BadgeClass="mud-width-full" SourceTemplate="@requirePasswordChangeFromTemplate">
+                                <TemplateOverride Class="mud-width-full" BadgeClass="mud-width-full" SourceTemplate="@_requirePasswordChangeFromTemplate">
                                     <MudSwitch Label=@AppLocalization[Lang.Allow_Username_Override]
                                                UncheckedColor="Color.Error"
                                                Color="Color.Success"
@@ -128,7 +128,7 @@
                             </MudStack>
                             <MudStack Row=true>
 
-                                <TemplateOverride Class="mud-width-full" BadgeClass="mud-width-full" SourceTemplate="@requirePasswordChangeFromTemplate">
+                                <TemplateOverride Class="mud-width-full" BadgeClass="mud-width-full" SourceTemplate="@_requirePasswordChangeFromTemplate">
                                     <MudSwitch Label=@AppLocalization[Lang.Require_Password_Change]
                                                UncheckedColor="Color.Warning"
                                                Color="Color.Success"
@@ -141,7 +141,7 @@
                             </MudStack>
                             <TemplateOverride Class="mud-width-full"
                                               BadgeClass="mud-width-full"
-                                              SourceTemplate="@sendWelcomeEmailFromTemplate">
+                                              SourceTemplate="@_sendWelcomeEmailFromTemplate">
 
                                 <MudSwitch Label="@AppLocalization[Lang.Send_Welcome_Email]"
                                            UncheckedColor="Color.Error"
@@ -162,7 +162,7 @@
 
                             <TemplateOverride Class="mud-width-full"
                                               BadgeClass="mud-width-full"
-                                              SourceTemplate="@askForAlternateEmailFromTemplate">
+                                              SourceTemplate="@_askForAlternateEmailFromTemplate">
 
                                 <MudSwitch Label="@AppLocalization[Lang.Ask_For_Alternate_Email]"
                                            UncheckedColor="Color.Error"
@@ -289,7 +289,7 @@
                                             <TemplateColumn StickyLeft=true Title=@AppLocalization[Lang.Name]>
                                                 <CellTemplate Context="cellContext">
                                                     @{
-                                                    var fromTemplateName = dropdownTemplates.FirstOrDefault(ot => ot.FieldValues.Contains(cellContext.Item));
+                                                    var fromTemplateName = _dropdownTemplates.FirstOrDefault(ot => ot.FieldValues.Contains(cellContext.Item));
                                                 }
                                                 <TemplateOverride SourceTemplate="@fromTemplateName">
                                                     <AppTooltip Text="@cellContext.Item.FieldName">

--- a/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor.cs
+++ b/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor.cs
@@ -8,15 +8,26 @@ namespace BLAZAM.Gui.UI.Settings.Templates
         private string? _testMiddleName;
         private string? _testLastName;
         private bool _showOuTree;
+        private AppModal? _categoryModal;
+        private List<DirectoryTemplate> _dropdownTemplates = [];
+        private DirectoryTemplate _template;
+        private DirectoryTemplate _workingTemplate = new();
+
+        private DirectoryTemplate _usernameFromTemplate;
+        private DirectoryTemplate _displayNameFromTemplate;
+        private DirectoryTemplate _passwordFromTemplateName;
+        private DirectoryTemplate _requirePasswordChangeFromTemplate;
+        private DirectoryTemplate _sendWelcomeEmailFromTemplate;
+        private DirectoryTemplate _askForAlternateEmailFromTemplate;
+
 
         [Parameter]
         public SetSubHeader? Header { get; set; }
 
 
-        private AppModal? categoryModal;
         protected string groupText;
         protected List<string> categories = [];
-        protected List<TemplateVariable> usernameVariables
+        protected List<TemplateVariable> UsernameVariables
         {
             get
             {
@@ -56,16 +67,7 @@ namespace BLAZAM.Gui.UI.Settings.Templates
             }
         }
 
-        private List<DirectoryTemplate> dropdownTemplates = [];
-        private DirectoryTemplate _template;
-        private DirectoryTemplate _workingTemplate = new();
-
-        private DirectoryTemplate usernameFromTemplate;
-        private DirectoryTemplate displayNameFromTemplate;
-        private DirectoryTemplate passwordFromTemplateName;
-        private DirectoryTemplate requirePasswordChangeFromTemplate;
-        private DirectoryTemplate sendWelcomeEmailFromTemplate;
-        private DirectoryTemplate askForAlternateEmailFromTemplate;
+       
 
 
         protected bool fieldDrawerOpen;
@@ -75,7 +77,6 @@ namespace BLAZAM.Gui.UI.Settings.Templates
         protected override async Task OnInitializedAsync()
         {
             await base.OnInitializedAsync();
-            await LoadData();
         }
         [Parameter]
         public DirectoryTemplate DirectoryTemplate
@@ -145,19 +146,19 @@ namespace BLAZAM.Gui.UI.Settings.Templates
 
                 SelectedOU = Directory?.OUs.FindOuByDN(_workingTemplate.EffectiveParentOU);
 
-                usernameFromTemplate = GetParentOfValue<string?>(_workingTemplate.EffectiveUsernameFormula, template => template.UsernameFormula);
-                displayNameFromTemplate = GetParentOfValue<string?>(_workingTemplate.EffectiveDisplayNameFormula, template => template.DisplayNameFormula);
-                passwordFromTemplateName = GetParentOfValue<string?>(_workingTemplate.EffectivePasswordFormula, template => template.PasswordFormula);
-                requirePasswordChangeFromTemplate = GetParentOfValue<bool?>(_workingTemplate.EffectiveRequirePasswordChange, template => template.RequirePasswordChange);
-                sendWelcomeEmailFromTemplate = GetParentOfValue<bool?>(_workingTemplate.EffectiveSendWelcomeEmail, template => template.SendWelcomeEmail);
-                askForAlternateEmailFromTemplate = GetParentOfValue<bool?>(_workingTemplate.EffectiveAskForAlternateEmail, template => template.AskForAlternateEmail); 
+                _usernameFromTemplate = GetParentOfValue<string?>(_workingTemplate.EffectiveUsernameFormula, template => template.UsernameFormula);
+                _displayNameFromTemplate = GetParentOfValue<string?>(_workingTemplate.EffectiveDisplayNameFormula, template => template.DisplayNameFormula);
+                _passwordFromTemplateName = GetParentOfValue<string?>(_workingTemplate.EffectivePasswordFormula, template => template.PasswordFormula);
+                _requirePasswordChangeFromTemplate = GetParentOfValue<bool?>(_workingTemplate.EffectiveRequirePasswordChange, template => template.RequirePasswordChange);
+                _sendWelcomeEmailFromTemplate = GetParentOfValue<bool?>(_workingTemplate.EffectiveSendWelcomeEmail, template => template.SendWelcomeEmail);
+                _askForAlternateEmailFromTemplate = GetParentOfValue<bool?>(_workingTemplate.EffectiveAskForAlternateEmail, template => template.AskForAlternateEmail); 
 
                 fields = await Context.ActiveDirectoryFields.Cast<IActiveDirectoryField>().ToListAsync();
                 fields.AddRange(await Context.CustomActiveDirectoryFields.Where(cf => cf.DeletedAt == null).Cast<IActiveDirectoryField>().ToListAsync());
-
+                
                 using (var dropdownContext = await DbFactory.CreateDbContextAsync())
                 {
-                    dropdownTemplates = await dropdownContext.DirectoryTemplates.Where(t => !t.Equals(_workingTemplate) && t.DeletedAt == null).ToListAsync();
+                    _dropdownTemplates = await dropdownContext.DirectoryTemplates.Where(t => !t.Equals(_workingTemplate) && t.DeletedAt == null).ToListAsync();
                 }
 
                 await LoadCategories();
@@ -267,6 +268,7 @@ namespace BLAZAM.Gui.UI.Settings.Templates
 
             using var categoryContext = await DbFactory.CreateDbContextAsync();
             categories = await categoryContext.DirectoryTemplates.Select(t => t.Category).Distinct().ToListAsync();
+            categories.Sort();
 
         }
 


### PR DESCRIPTION
Renamed private fields with underscore prefix for clarity and updated all references in EditDirectoryTemplate.razor and its code-behind. Also sorted categories after loading. No functional changes; improves code readability and naming consistency.