### PR TITLE
Refactor template tree view and update version

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.6</AssemblyVersion>
-		<Version>2026.04.22.1815</Version>
+		<Version>2026.04.22.1841</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMGui/UI/Outputs/TemplateInheritanceTreeView.razor
+++ b/BLAZAMGui/UI/Outputs/TemplateInheritanceTreeView.razor
@@ -4,29 +4,29 @@
     <MudText>@Label</MudText>
 }
 
-    <MudTreeView T="DirectoryTemplate"
-                 Items="RootTemplate"
-                 AutoExpand=true
-                 Dense="true"
-                 Hover="true"
-                 Class="py-3"
-                 SelectedValue="SelectedTemplate"
-                 SelectedValueChanged=SelectedTemplateChanged
-                 MaxHeight="400px">
+<MudTreeView T="DirectoryTemplate"
+             Items="RootTemplate"
+             AutoExpand=true
+             Dense="true"
+             Hover="true"
+             Class="py-3"
+             SelectedValue="SelectedTemplate"
+             SelectedValueChanged=SelectedTemplateChanged
+             MaxHeight="400px">
     <ItemTemplate>
-        <MudTreeViewItem Selected=@(context.Value.Id.Equals(SelectedTemplate?.Id)==true)
+        <MudTreeViewItem Selected=@(context.Value.Id.Equals(SelectedTemplate?.Id) == true)
                          Expanded="context.Expanded"
                          Items="@context.Children"
                          Value="@context.Value">
             <Content>
-                <MudTreeViewItemToggleButton ExpandedChanged="@((state)=>{context.Expanded=state;})"
+                <MudTreeViewItemToggleButton ExpandedChanged="@((state) => { context.Expanded = state; })"
                                              Visible="@(context.HasChildren)" />
-
-                <MudBadge Icon="@Icons.Material.Filled.VisibilityOff"
-                          Visible=@(!context.Value.Visible)
-                          Color="Color.Warning">
-                    @context.Value.Name
-                </MudBadge>
+                <MudText>@context.Value.Name</MudText>
+                @if (context.Value.Visible!=true)
+                {
+                    <MudIcon Icon="@Icons.Material.Filled.VisibilityOff"
+                             Color="Color.Warning"/>
+                }
             </Content>
         </MudTreeViewItem>
     </ItemTemplate>


### PR DESCRIPTION
Refactored TemplateInheritanceTreeView to use MudText for template names and display a VisibilityOff icon when not visible, replacing the previous MudBadge approach. Updated project version to 2026.04.22.1841. Minor formatting improvements.