### PR TITLE
Update dependencies

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.6</AssemblyVersion>
-		<Version>2026.05.06.2340</Version>
+		<Version>2026.05.07.0017</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,9 +10,9 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.0" />
     <PackageVersion Include="DuoUniversal" Version="1.3.1" />
-    <PackageVersion Include="Google.Apis" Version="1.73.0" />
-    <PackageVersion Include="Google.Apis.Admin.Directory.directory_v1" Version="1.73.0.4075" />
-    <PackageVersion Include="Google.Apis.Auth" Version="1.73.0" />
+    <PackageVersion Include="Google.Apis" Version="1.74.0" />
+    <PackageVersion Include="Google.Apis.Admin.Directory.directory_v1" Version="1.73.0.4128" />
+    <PackageVersion Include="Google.Apis.Auth" Version="1.74.0" />
     <PackageVersion Include="GoogleAuthenticator" Version="3.2.0" />
     <PackageVersion Include="MailKit" Version="4.16.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.26" />
@@ -28,25 +28,25 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.26" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.26" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.26" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.59.0" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.14" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="MudBlazor" Version="9.3.0" />
+    <PackageVersion Include="MudBlazor" Version="9.4.0" />
     <PackageVersion Include="MudBlazor.Markdown" Version="9.0.0" />
     <PackageVersion Include="MudBlazor.ThemeManager" Version="3.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NUnit" Version="4.5.1" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
+    <PackageVersion Include="NUnit" Version="4.6.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.13.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="Octokit" Version="14.0.0" />
     <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
@@ -61,14 +61,14 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
     <PackageVersion Include="System.Data.SQLite" Version="2.0.3" />
-    <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.6" />
-    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.6" />
-    <PackageVersion Include="System.DirectoryServices" Version="10.0.6" />
-    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="10.0.6" />
-    <PackageVersion Include="System.DirectoryServices.Protocols" Version="10.0.6" />
-    <PackageVersion Include="System.Drawing.Common" Version="10.0.6" />
-    <PackageVersion Include="System.Management" Version="10.0.6" />
-    <PackageVersion Include="System.Security.Permissions" Version="10.0.6" />
+    <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.7" />
+    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.7" />
+    <PackageVersion Include="System.DirectoryServices" Version="10.0.7" />
+    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="10.0.7" />
+    <PackageVersion Include="System.DirectoryServices.Protocols" Version="10.0.7" />
+    <PackageVersion Include="System.Drawing.Common" Version="10.0.7" />
+    <PackageVersion Include="System.Management" Version="10.0.7" />
+    <PackageVersion Include="System.Security.Permissions" Version="10.0.7" />
     <PackageVersion Include="TaskScheduler" Version="2.12.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
Updated project version to 2026.05.07.0017. Bumped multiple NuGet package dependencies to their latest versions, including Google.Apis, Microsoft.Extensions.*, MudBlazor, NUnit, and various System.* libraries. No packages were added or removed; only version updates were performed.