### PR TITLE
Sort template categories on create user page and update category binding on edit template page for #1430 and #1431

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.5.7</AssemblyVersion>
-		<Version>2026.05.07.2154</Version>
+		<Version>2026.05.08.2101</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor
+++ b/BLAZAMGui/UI/Settings/Templates/EditDirectoryTemplate.razor
@@ -30,7 +30,7 @@
                                        OnAdornmentClick="@(()=>{_=_categoryModal?.ShowAsync();})"
                                        Options="@(categories.Count>0?categories:new List<string>())"
                                        ValueChanged="@((value)=>{_workingTemplate.Category=value;})"
-                                       @bind-Text=_workingTemplate.Category
+                                       Value="@_workingTemplate.Category"
                                        Label="@AppLocalization[Lang.Template_Category]" />
                         <AppModal @ref=_categoryModal Title=@AppLocalization[Lang.Add_Category]>
                             <AddTemplateCategoryModalContent Categories="@categories"

--- a/BLAZAMGui/UI/TemplateComponent.razor.cs
+++ b/BLAZAMGui/UI/TemplateComponent.razor.cs
@@ -56,7 +56,7 @@ namespace BLAZAM.Gui.UI
         {
             get
             {
-                var cats = TemplatesUserCanUse.Select(c => c.Category).Where(c => c != "" && c != null).Distinct().ToList();
+                var cats = TemplatesUserCanUse.Select(c => c.Category).Where(c => c != "" && c != null).Distinct().OrderBy(x=>x).ToList();
                 return cats;
             }
         }
@@ -141,7 +141,7 @@ namespace BLAZAM.Gui.UI
                     Templates = temp;
                 }
 
-                var cats = await Context.DirectoryTemplates.Select(c => c.Category).Where(c => c != "" && c != null).Distinct().ToListAsync();
+                var cats = await Context.DirectoryTemplates.Select(c => c.Category).Where(c => c != "" && c != null).Distinct().OrderBy(x=>x).ToListAsync();
                 if (cats != null)
                 {
                     TemplateCategories = cats;


### PR DESCRIPTION
Updated category lists to be ordered alphabetically in TemplateComponent.razor.cs for consistent display. Replaced @bind-Text with Value in EditDirectoryTemplate.razor to match component parameters. Bumped project version to 2026.05.08.2101.