### PR TITLE
Update .NET Core SDK to 10.x in deploy workflow

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET Core SDK 10
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 8.x
+          dotnet-version: 10.x
       - name: Build with dotnet
         run: dotnet build --configuration Release
 


### PR DESCRIPTION
Updated the GitHub Actions workflow to use .NET Core SDK version 10.x instead of 8.x by changing the dotnet-version input in the setup step. This ensures the build uses the latest SDK version.