### PR TITLE
Update release workflow to use Net10 prefix

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -66,8 +66,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
         with:
-          tag_name: Release-v${{ env.ASSEMBLY_VERSION }}
-          release_name: Release - v${{ env.ASSEMBLY_VERSION }}
+          tag_name: Net10-v${{ env.ASSEMBLY_VERSION }}
+          release_name: Net10 - v${{ env.ASSEMBLY_VERSION }}
           body: ""
           draft: true
           prerelease: true


### PR DESCRIPTION
Changed tag_name and release_name in release-stable.yml to use the "Net10" prefix instead of "Release", ensuring release tags and names are now formatted as "Net10-v${{ env.ASSEMBLY_VERSION }}" and "Net10 - v${{ env.ASSEMBLY_VERSION }}".