### PR TITLE
Refactor prereq checks, remove update method, bump version

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.6.0</AssemblyVersion>
-		<Version>2026.05.21.2118</Version>
+		<Version>2026.05.21.2212</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMCommon/Data/PrerequisiteChecker.cs
+++ b/BLAZAMCommon/Data/PrerequisiteChecker.cs
@@ -1,4 +1,7 @@
-﻿namespace BLAZAM.Common.Data
+﻿using Microsoft.Win32;
+using SixLabors.ImageSharp.ColorProfiles;
+
+namespace BLAZAM.Common.Data
 {
     public static class PrerequisiteChecker
     {
@@ -75,9 +78,10 @@
 
         private static bool CheckForAspCoreHosting(string version = "8")
         {
+            RegistryKey? key=null;
             try
             {
-                var key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey("SOFTWARE\\WOW6432Node\\Microsoft\\Updates\\.NET\\");
+                key = Registry.LocalMachine.OpenSubKey("SOFTWARE\\WOW6432Node\\Microsoft\\Updates\\.NET\\");
                 if (key != null)
                 {
                     var possibleAspKeys = key.GetSubKeyNames();
@@ -96,6 +100,10 @@
             catch (Exception ex)
             {
                 Loggers.SystemLogger.Error(ex, "Error checking for ASP.NET Core Hosting prerequisites.");
+            }
+            finally
+            {
+                key?.Dispose();
             }
             return false;
         }

--- a/BLAZAMUpdate/Services/UpdateService.cs
+++ b/BLAZAMUpdate/Services/UpdateService.cs
@@ -370,18 +370,6 @@ namespace BLAZAM.Update.Services
             return false;
         }
 
-        private async void CheckForUpdate(object? state)
-        {
-            try
-            {
-                await GetUpdates();
-            }
-            catch (Exception ex)
-            {
-                Loggers.UpdateLogger.Error(ex, "Error while checking for latest update");
-
-            }
-        }
 
         /// <summary>
         /// The type of credential validated to be able to write to the app directory


### PR DESCRIPTION
- Updated project version to 2026.05.21.2212 in BLAZAM.csproj.
- Improved resource management in PrerequisiteChecker by disposing RegistryKey properly.
- Added missing using directives in PrerequisiteChecker.cs.
- Removed unused async CheckForUpdate method from UpdateService.cs.