### PR TITLE
Update version and fix UTC time comparison logic

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.6.0</AssemblyVersion>
-		<Version>2026.05.21.2212</Version>
+		<Version>2026.05.21.2218</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMSession/Helpers/SessionHelpers.cs
+++ b/BLAZAMSession/Helpers/SessionHelpers.cs
@@ -69,7 +69,7 @@ namespace BLAZAM.Helpers
                 var currentUtc = DateTimeOffset.UtcNow;
                 if (!ticket.Properties.IssuedUtc.HasValue ||
                     (ticket.Properties.ExpiresUtc.HasValue &&
-                    ticket.Properties.ExpiresUtc < DateTime.UtcNow))
+                    ticket.Properties.ExpiresUtc < DateTimeOffset.UtcNow))
                 {
                     return;
                 }


### PR DESCRIPTION
Updated project version to 2026.05.21.2218 in BLAZAM.csproj. Replaced DateTime.UtcNow with DateTimeOffset.UtcNow in SessionHelpers.cs to ensure consistent and correct UTC time comparisons for session expiration logic.