### PR TITLE
Fix Group creation API checking User creation permissions

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
-		<AssemblyVersion>1.6.1</AssemblyVersion>
+		<AssemblyVersion>1.6.2</AssemblyVersion>
 		<Version>2026.08.21.1429</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>

--- a/BLAZAM/Pages/API/v1/Group.cs
+++ b/BLAZAM/Pages/API/v1/Group.cs
@@ -1,4 +1,5 @@
 using BLAZAM.ActiveDirectory.Interfaces;
+using BLAZAM.Common.Data;
 using BLAZAM.Pages.API.Data;
 using BLAZAM.Services.Audit;
 using BLAZAM.Session.Interfaces;
@@ -55,7 +56,7 @@ namespace BLAZAM.Pages.API.v1
                 {
                     return NotFound("OU not found");
                 }
-                if (!ou.CanCreateUser)
+                if (!ou.CanCreateType(ActiveDirectoryObjectType.Group))
                 {
                     return Forbid("You do not have permission to create groups in this OU");
                 }
@@ -86,6 +87,7 @@ namespace BLAZAM.Pages.API.v1
 
         private void AssignToGroups(NewGroupDetails newGroupDetails, IADGroup newGroup)
         {
+            
             if (newGroupDetails.Groups != null)
             {
                 foreach (var groupIdentifier in newGroupDetails.Groups)

--- a/BLAZAMActiveDirectory/Adapters/ADOrganizationalUnit.cs
+++ b/BLAZAMActiveDirectory/Adapters/ADOrganizationalUnit.cs
@@ -196,14 +196,12 @@ namespace BLAZAM.ActiveDirectory.Adapters
             }
 
         }
-        public virtual bool CanCreateUser
-        {
-            get
-            {
-                return HasActionPermission(ObjectActions.Create, ActiveDirectoryObjectType.User);
-            }
-
+        public virtual bool CanCreateType(ActiveDirectoryObjectType objectType)
+        {          
+                return HasActionPermission(ObjectActions.Create, objectType);
         }
+        public virtual bool CanCreateUser=>CanCreateType(ActiveDirectoryObjectType.User);
+       
         public virtual bool CanCreateUserInSubOUs
         {
             get

--- a/BLAZAMActiveDirectory/Interfaces/IADOrganizationalUnit.cs
+++ b/BLAZAMActiveDirectory/Interfaces/IADOrganizationalUnit.cs
@@ -1,4 +1,5 @@
 ﻿using BLAZAM.ActiveDirectory.Adapters;
+using BLAZAM.Common.Data;
 
 namespace BLAZAM.ActiveDirectory.Interfaces
 {
@@ -31,6 +32,11 @@ namespace BLAZAM.ActiveDirectory.Interfaces
         /// Gets a value indicating whether the current user has permission to create users in this OU.
         /// </summary>
         bool CanCreateUser { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the current user has permission to create users in this OU.
+        /// </summary>
+        bool CanCreateType(ActiveDirectoryObjectType type);
 
         /// <summary>
         /// Gets a value indicating whether the current user has permission to create users in sub-organizational units.

--- a/BLAZAMDatabase/Context/SqliteDatabaseContext.cs
+++ b/BLAZAMDatabase/Context/SqliteDatabaseContext.cs
@@ -34,7 +34,7 @@ namespace BLAZAM.Database.Context
             {
                 if (ex.InnerException?.HResult == -2147467259)
                 {
-                    await Task.Delay(500, cancellationToken);
+                    await Task.Delay(500, CancellationToken.None);
                     return await RetrySaveChangesAsync(cancellationToken);
                 }
                 return -1;
@@ -56,7 +56,7 @@ namespace BLAZAM.Database.Context
             {
                 if (retries < 15 && ex.InnerException?.HResult == -2147467259)
                 {
-                    await Task.Delay(500, cancellationToken);
+                    await Task.Delay(500, CancellationToken.None);
                     return await RetrySaveChangesAsync(cancellationToken, retries + 1);
                 }
                 return -1;

--- a/BLAZAMJobs/JobStepBase.cs
+++ b/BLAZAMJobs/JobStepBase.cs
@@ -89,7 +89,7 @@ namespace BLAZAM.Jobs
                 thread.Start();
                 while (Result != JobResult.Passed && Result != JobResult.Failed && Result != JobResult.Cancelled)
                 {
-                    await Task.Delay(500, cancellationTokenSource.Token);
+                    await Task.Delay(500, CancellationToken.None);
                 }
                 return Result == JobResult.Passed;
             }

--- a/BLAZAMLoggers/Loggers.cs
+++ b/BLAZAMLoggers/Loggers.cs
@@ -162,7 +162,9 @@ namespace BLAZAM.Logger
                     });
             if (SendToSeqServer)
             {
-                systemLoggerBuilder.WriteTo.Seq(SeqServerUri, apiKey: SeqAPIKey, restrictedToMinimumLevel: LogEventLevel.Warning);
+                systemLoggerBuilder.WriteTo.Seq(SeqServerUri,
+                    apiKey: SeqAPIKey,
+                    restrictedToMinimumLevel: LogEventLevel.Warning);
             }
             Log.Logger = systemLoggerBuilder.CreateLogger();
             SystemLogger = Log.Logger;
@@ -191,12 +193,12 @@ namespace BLAZAM.Logger
         {
             var loggerBuilder = CreateLogBuilder()
                 .WriteTo.File(logFilePath,
-                rollingInterval: rollingInterval,
+                    rollingInterval: rollingInterval,
                     retainedFileCountLimit: null,
                     fileSizeLimitBytes: 10000000,
                     rollOnFileSizeLimit: true,
-         outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}{NewLine}{Exception}",
-         retainedFileTimeLimit: TimeSpan.FromDays(30));
+                    outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}{NewLine}{Exception}",
+                    retainedFileTimeLimit: TimeSpan.FromDays(30));
             if (!Debugger.IsAttached)
             {
                 loggerBuilder.WriteTo.Logger(lc =>
@@ -214,7 +216,9 @@ namespace BLAZAM.Logger
 
             if (SendToSeqServer)
             {
-                loggerBuilder.WriteTo.Seq(SeqServerUri, apiKey: SeqAPIKey, restrictedToMinimumLevel: LogEventLevel.Warning);
+                loggerBuilder.WriteTo.Seq(SeqServerUri,
+                    apiKey: SeqAPIKey,
+                    restrictedToMinimumLevel: LogEventLevel.Warning);
             }
 
             return loggerBuilder.CreateLogger();

--- a/BLAZAMUpdate/ApplicationUpdate.cs
+++ b/BLAZAMUpdate/ApplicationUpdate.cs
@@ -458,7 +458,7 @@ namespace BLAZAM.Update
                         else
                         {
                             Loggers.UpdateLogger?.Warning(ex, "Download failed, {RemainingRetries} retries remaining. Waiting 3 seconds before retry", retries);
-                            await Task.Delay(3000, _cancellationTokenSource.Token);
+                            await Task.Delay(3000, CancellationToken.None);
                         }
                     }
                 }


### PR DESCRIPTION
Replaced cancellable Task.Delay calls with non-cancellable ones using CancellationToken.None in retry, wait, and update logic, making delays uninterruptible. Reformatted logger configuration code for readability without changing functionality.