### PR TITLE
Update ADTreeItem parameter and add item selection handler

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.6.2</AssemblyVersion>
-		<Version>2026.08.30.1938</Version>
+		<Version>2026.08.31.1302</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAM/Pages/API/v1/Templates.cs
+++ b/BLAZAM/Pages/API/v1/Templates.cs
@@ -115,12 +115,19 @@ namespace BLAZAM.Pages.API.v1
             try
             {
                 var customOU = Directory.OUs.FindOuByDN(newUserDetails.OU);
-                if (customOU == null && template.EffectiveParentOU == null)
+                IADOrganizationalUnit? templateOU = null;
+                if (template.EffectiveParentOU != null)
+                {
+                    templateOU = Directory.OUs.FindOuByDN(template.EffectiveParentOU);
+
+                }
+                if (customOU == null && templateOU == null)
                 {
                     return new BadRequestObjectResult("There was no OU provided by API call or template!");
                 }
+                var newUserOU = customOU ?? templateOU;
                 //Generate IADUser
-                var newUser = await template.GenerateTemplateUserAsync(newUserName, Directory, customOU);
+                var newUser = await template.GenerateTemplateUserAsync(newUserName, Directory, newUserOU);
                 if (newUser == null)
                 {
                     return new UnprocessableEntityObjectResult("Could not generate user from template");

--- a/BLAZAMGui/UI/Inputs/TreeViews/ADTreeItem.razor
+++ b/BLAZAMGui/UI/Inputs/TreeViews/ADTreeItem.razor
@@ -1,5 +1,4 @@
 @inherits AppComponentBase
-
 <MudText>@Item.Value?.CanonicalName</MudText>
 <MudSpacer />
 <LoadingData Loading="LoadingData" />
@@ -8,13 +7,13 @@
     <MudText>@_endText</MudText>
 }
 
-
                  
                  
 
 @code {
 
     private string? _endText = null;
+
 
     [Parameter]
     public MudTreeViewItem<IDirectoryEntryAdapter>? Item { get; set; } = default;

--- a/BLAZAMGui/UI/Inputs/TreeViews/ADTreeView.razor
+++ b/BLAZAMGui/UI/Inputs/TreeViews/ADTreeView.razor
@@ -14,6 +14,7 @@
                          CanExpand=@(context.Value is IADOrganizationalUnit)
                          Items="@context.Children"
                          Icon="@context.Value?.TypeIcon()"
+                         OnClick="@(() => {SelectedEntry=context.Value;})"
                          Selected="@(context.Value?.Equals(SelectedEntry) == true)"
                          LoadingIconColor="Color.Info"
                          Value="@context.Value">


### PR DESCRIPTION
Refactored ADTreeItem.razor to use a new Item parameter of type MudTreeViewItem<IDirectoryEntryAdapter>?. Updated ADTreeView.razor to handle item selection via OnClick and pass the Item parameter to ADTreeItem. Bumped project version to 2026.08.31.1302.