### PR TITLE
Update NuGet dependencies

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.6.4</AssemblyVersion>
-		<Version>2026.09.10.1439</Version>
+		<Version>2026.09.10.2129</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.6.4</AssemblyVersion>
-		<Version>2026.09.10.2129</Version>
+		<Version>2026.09.10.2158</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMCommon/Helpers/CommonHelpers.cs
+++ b/BLAZAMCommon/Helpers/CommonHelpers.cs
@@ -421,6 +421,10 @@ namespace BLAZAM.Helpers
 
             if (value is DateTime dtValue)
             {
+                if(dtValue==DateTime.Parse("1/1/1601 12:00:00AM", CultureInfo.InvariantCulture))
+                {
+                    return null;
+                }   
                 return dtValue;
             }
 

--- a/BLAZAMEmailMessage/Email/EmailTemplateRenderer.cs
+++ b/BLAZAMEmailMessage/Email/EmailTemplateRenderer.cs
@@ -16,9 +16,9 @@ namespace BLAZAM.EmailMessage.Email
             this.UseLayout<DefaultEmailLayout>();
             this.AddServiceProvider(ApplicationInfo.services);
         }
-        public new ComponentRenderer<TComponent> Set<TValue>(Expression<Func<TComponent, TValue>> parameterSelector, TValue value)
+        public new EmailTemplateRenderer<TComponent> Set<TValue>(Expression<Func<TComponent, TValue>> parameterSelector, TValue value)
         {
-            if (value != null)
+            if (!EqualityComparer<TValue>.Default.Equals(value, default(TValue)))
             {
                 base.Set(parameterSelector, value); 
             }

--- a/BLAZAMGui/UI/Outputs/DirectoryEntryTooltipPopover.razor
+++ b/BLAZAMGui/UI/Outputs/DirectoryEntryTooltipPopover.razor
@@ -7,9 +7,9 @@
         </ActivatorContent>
         <PopoverContent>
             <MudElement Class="pa-1">
-                
+
                 <MudText Align=Align.Center><MudLink Href="@Entry?.SearchUri">@Entry?.CanonicalName</MudLink></MudText>
-                @if (GroupableEntry?.Description.IsNullOrEmpty()==false)
+                @if (GroupableEntry?.Description.IsNullOrEmpty() == false)
                 {
                     <MudText Align=Align.Center>
                         <MudText Typo=Typo.caption Align=Align.Center>@GroupableEntry.Description</MudText>
@@ -47,15 +47,14 @@
                 </MudStack>
                 @if (User != null)
                 {
-                    <MudStack Row=true>
-
-                        <MudText Typo="Typo.subtitle2">@AppLocalization[Lang.Pass_Change]:</MudText>
-                        <MudSpacer />
-                        <DateWithTimeTooltip DateTime="User.PasswordLastSet" />
-
-                     
-                    </MudStack>
-                
+                    @if (User.CanSetPassword)
+                    {
+                        <MudStack Row=true>
+                            <MudText Typo="Typo.subtitle2">@AppLocalization[Lang.Pass_Change]:</MudText>
+                            <MudSpacer />
+                            <DateWithTimeTooltip DateTime="User.PasswordLastSet" />
+                        </MudStack>
+                    }
                     <MudStack Row=true>
 
                         <MudText Typo="Typo.subtitle2">@AppLocalization[Lang.Last_Logon]:</MudText>

--- a/BLAZAMGui/UI/Users/Sections/DetailsSection.razor
+++ b/BLAZAMGui/UI/Users/Sections/DetailsSection.razor
@@ -8,7 +8,7 @@
 <ViewSection Title="@AppLocalization["User Details"]" Stack=true FullWidth=false>
 
     <ContactThumbnailPhoto Contact=Contact />
-    
+
     <DetailsField Label="@AppLocalization[Lang.Created]">
         <DateWithTimeTooltip DateTime="GroupableEntry?.Created" />
     </DetailsField>
@@ -16,15 +16,16 @@
     <DetailsField Label="@AppLocalization[Lang.Last_Change]">
         <DateWithTimeTooltip DateTime="GroupableEntry?.LastChanged" />
     </DetailsField>
+
     
-   
     @if (User != null)
     {
-        
-        <DetailsField Label="@AppLocalization[Lang.Pass_Change]">
-            <DateWithTimeTooltip DateTime="User?.PasswordLastSet" />
-        </DetailsField>
-        
+        @if (User.CanSetPassword)
+        {
+            <DetailsField Label="@AppLocalization[Lang.Pass_Change]">
+                <DateWithTimeTooltip DateTime="User?.PasswordLastSet" />
+            </DetailsField>
+        }
         <DetailsField Label="@AppLocalization[Lang.Last_Logon]">
             <LastLogonTime Typo=Typo.caption DirectoryEntry="Account" />
         </DetailsField>
@@ -37,10 +38,10 @@
             </DetailsField>
         }
     }
-    
+
     <DetailsField Label="@AppLocalization[Lang.OU]" Value="@Entry?.OU.ToPrettyOu()" />
 
-       <MudStack>
+    <MudStack>
         <MudText Typo="Typo.subtitle2">@AppLocalization[Lang.Groups]:</MudText>
         <MemberOfList AssignToClicked=@AssignToClicked Model="GroupableEntry" />
     </MudStack>

--- a/BLAZAMLocalization/Lang.cs
+++ b/BLAZAMLocalization/Lang.cs
@@ -317,6 +317,7 @@
         public static readonly string Change_Password = "Change Password";
         public static readonly string Last_Change = "Last Change";
         public static readonly string Pass_Change = "Pass Change";
+        public static readonly string Password_Expiration = "Password Expiration";
         public static readonly string Lockout_Time = "Lockout Time";
         public static readonly string Last_Logon = "Last Logon";
         public static readonly string LAPS_Password = "LAPS Password";

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,44 +4,44 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BlazorTemplater" Version="1.5.1" />
-    <PackageVersion Include="bunit" Version="2.9.0" />
+    <PackageVersion Include="bunit" Version="2.10.3" />
     <PackageVersion Include="bunit.web" Version="1.40.0" />
     <PackageVersion Include="Cassia" Version="2.0.0.60" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
     <PackageVersion Include="DuoUniversal" Version="1.3.1" />
     <PackageVersion Include="Google.Apis" Version="1.76.0" />
-    <PackageVersion Include="Google.Apis.Admin.Directory.directory_v1" Version="1.75.0.4227" />
+    <PackageVersion Include="Google.Apis.Admin.Directory.directory_v1" Version="1.76.0.4262" />
     <PackageVersion Include="Google.Apis.Auth" Version="1.76.0" />
     <PackageVersion Include="GoogleAuthenticator" Version="3.2.0" />
     <PackageVersion Include="MailKit" Version="4.17.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.ResponseCompression" Version="2.3.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.ResponseCompression" Version="2.3.13" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="5.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.9.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.19" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.19" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.19" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.19" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.19" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.19" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.19" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.20" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.20" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.20" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.20" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.20" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.20" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.20" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
     <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.62.0" />
-    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.6.5" />
+    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.6.6" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MudBlazor" Version="9.9.0" />
     <PackageVersion Include="MudBlazor.Markdown" Version="9.0.0" />
@@ -63,14 +63,14 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
     <PackageVersion Include="System.Data.SQLite" Version="2.0.4" />
-    <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.11" />
-    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.11" />
-    <PackageVersion Include="System.DirectoryServices" Version="10.0.11" />
-    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="10.0.11" />
-    <PackageVersion Include="System.DirectoryServices.Protocols" Version="10.0.11" />
-    <PackageVersion Include="System.Drawing.Common" Version="10.0.11" />
-    <PackageVersion Include="System.Management" Version="10.0.11" />
-    <PackageVersion Include="System.Security.Permissions" Version="10.0.11" />
+    <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.12" />
+    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.12" />
+    <PackageVersion Include="System.DirectoryServices" Version="10.0.12" />
+    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="10.0.12" />
+    <PackageVersion Include="System.DirectoryServices.Protocols" Version="10.0.12" />
+    <PackageVersion Include="System.Drawing.Common" Version="10.0.12" />
+    <PackageVersion Include="System.Management" Version="10.0.12" />
+    <PackageVersion Include="System.Security.Permissions" Version="10.0.12" />
     <PackageVersion Include="TaskScheduler" Version="2.12.2" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />


### PR DESCRIPTION
﻿
- Bumped project version in BLAZAM.csproj to 2026.09.10.2129.
- Updated multiple NuGet packages in Directory.Packages.props to latest patch versions, including bunit, Google.Apis.Admin.Directory.directory_v1, Microsoft.AspNetCore.*, Microsoft.EntityFrameworkCore.*, Microsoft.Extensions.*, Microsoft.NET.Test.Sdk, Microsoft.PowerShell.SDK, and various System.* packages.
- No code logic changes; only version and dependency updates.