### PR TITLE
Enable Require Password Change switch if web user can set password

### DIFF
--- a/BLAZAMGui/UI/Users/Sections/AccountSection.razor
+++ b/BLAZAMGui/UI/Users/Sections/AccountSection.razor
@@ -104,7 +104,7 @@
                            ThumbIconColor="@(Account.RequirePasswordChange==true?Color.Success:Color.Default)"
                            Label=@AppLocalization[Lang.Require_Password_Change]
                            Value=@Account.RequirePasswordChange
-                           Disabled=@true />
+                           Disabled=@(!EditMode || !Account.CanSetPassword) />
 
             }
         </MudStack>


### PR DESCRIPTION
Previously, the MudSwitch for "Require Password Change" was always disabled. Now, it is enabled when EditMode is true and Account.CanSetPassword is true, allowing users to modify the setting when permitted.