### PR TITLE
Add Password Never Expires property and UI support

### DIFF
--- a/BLAZAM/BLAZAM.csproj
+++ b/BLAZAM/BLAZAM.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>
 		<AssemblyVersion>1.6.4</AssemblyVersion>
-		<Version>2026.09.10.2329</Version>
+		<Version>2026.09.11.2235</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<RootNamespace>BLAZAM</RootNamespace>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/BLAZAMActiveDirectory/Adapters/AccountDirectoryAdapter.cs
+++ b/BLAZAMActiveDirectory/Adapters/AccountDirectoryAdapter.cs
@@ -169,6 +169,36 @@ namespace BLAZAM.ActiveDirectory.Adapters
                 }
             }
         }
+        public virtual bool PasswordNeverExpires
+        {
+            get
+            {
+
+                try
+                {
+                    return (UAC & ADS_UF_DONT_EXPIRE_PASSWD) == ADS_UF_DONT_EXPIRE_PASSWD;
+                }
+                catch
+                {
+                    //Ignore error
+                }
+                return true;
+            }
+            set
+            {
+                if (value && !PasswordNeverExpires)
+                {
+                    UAC = UAC | ADS_UF_DONT_EXPIRE_PASSWD;
+                }
+                else if (!value && PasswordNeverExpires)
+                {
+
+                    UAC = UAC & ~ADS_UF_DONT_EXPIRE_PASSWD;
+
+                }
+            }
+        }
+
         public virtual bool PasswordNotRequired
         {
             get
@@ -328,39 +358,8 @@ namespace BLAZAM.ActiveDirectory.Adapters
         }
         public DateTime? PasswordLastSet
         {
-            get
-            {
-
-                try
-                {
-                    var dateTime = GetDateTimeAttribute(pwdLastSet)?.AdsValueToDateTime();
-                    if (dateTime.HasValue)
-                    {
-                        return dateTime.Value;
-
-                    }
-                }
-                catch
-                {
-                    try
-                    {
-                        var rawValue = GetAttribute<Int32>(pwdLastSet);
-                        if (rawValue == -1)
-                        {
-                            return DateTime.UtcNow;
-                        }
-                        if (rawValue == 0)
-                        {
-                            return null;
-                        }
-                    }
-                    catch
-                    {
-                        //Ignore conversion errors during runtime
-                    }
-                }
-                return null;
-            }
+            get=>GetDateTimeAttribute(pwdLastSet);
+            
             set
             {
                 if (value == null)

--- a/BLAZAMActiveDirectory/Interfaces/IAccountDirectoryAdapter.cs
+++ b/BLAZAMActiveDirectory/Interfaces/IAccountDirectoryAdapter.cs
@@ -93,6 +93,11 @@ namespace BLAZAM.ActiveDirectory.Interfaces
         bool RequirePasswordChange { get; set; }
 
         /// <summary>
+        /// Indicates whether the account's password is set to never expire.
+        /// </summary>
+        bool PasswordNeverExpires { get; set; }
+
+        /// <summary>
         /// The last logon timestamp as replicated across domain controllers.
         /// </summary>
         DateTime? LastLogonTimestamp { get; }

--- a/BLAZAMGui/UI/Users/Sections/AccountSection.razor
+++ b/BLAZAMGui/UI/Users/Sections/AccountSection.razor
@@ -1,5 +1,4 @@
-﻿
-@inherits DirectoryModelComponentElement
+﻿@inherits DirectoryModelComponentElement
 
 
 
@@ -105,7 +104,12 @@
                            Label=@AppLocalization[Lang.Require_Password_Change]
                            Value=@Account.RequirePasswordChange
                            Disabled=@true />
-
+                <MudSwitch T=bool
+                           Color=Color.Success
+                           ThumbIconColor="@(Account.PasswordNeverExpires==true?Color.Success:Color.Default)"
+                           Label=@AppLocalization[Lang.Password_Never_Expires]
+                           @bind-Value=@Account.PasswordNeverExpires
+                           Disabled=@(!EditMode || !Account.CanSetPassword) />
             }
         </MudStack>
         @if (CurrentUser.State.IsSuperAdmin)
@@ -127,9 +131,9 @@
             }
         }
 
-       <PluginComponents Page="@PageType.User" Location="@PageLocation.Account"/>
-     
+        <PluginComponents Page="@PageType.User" Location="@PageLocation.Account" />
 
+     
 
     </ViewSection>
 


### PR DESCRIPTION
Added PasswordNeverExpires to AccountDirectoryAdapter and IAccountDirectoryAdapter for reading and setting the "password never expires" flag. Updated AccountSection.razor to display and edit this setting with a MudSwitch. Simplified PasswordLastSet getter logic. Minor formatting fixes and updated project version in BLAZAM.csproj.